### PR TITLE
Remove socket.io and convert to REST API + SSE across ide, tools, and…

### DIFF
--- a/ide/run_ide.py
+++ b/ide/run_ide.py
@@ -5,18 +5,24 @@ import shutil
 import base64
 import datetime
 import subprocess
+import json
 import requests
 from pathlib import Path
-from typing import List, Union
+from typing import List
 
-from fastapi import FastAPI, Request, UploadFile, File, Form, Body, Depends
-from fastapi.responses import HTMLResponse, FileResponse, JSONResponse, RedirectResponse
+from fastapi import FastAPI, Request, UploadFile, File, Body
+from fastapi.responses import HTMLResponse, FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi_socketio import SocketManager
-from starlette.websockets import WebSocketDisconnect
 from fastapi.templating import Jinja2Templates
 from contextlib import asynccontextmanager
+
+# SSE broadcast: list of asyncio.Queue per connected client
+sse_clients: list = []
+
+async def broadcast(data: dict):
+  for q in sse_clients:
+    await q.put(data)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -25,14 +31,12 @@ async def lifespan(app: FastAPI):
 
 try:
   app = FastAPI(lifespan=lifespan)
-  socket_manager = SocketManager(app=app, mount_location='/socket.io')
   templates = Jinja2Templates(directory="templates")
-
   app.mount("/static", StaticFiles(directory="static"), name="static")
   app.mount("/svg", StaticFiles(directory="svg"), name="svg")
   app.mount("/webfonts", StaticFiles(directory="webfonts"), name="webfonts")
 except Exception as ex:
-  print(f'Server error{ex}')
+  print(f'Server error: {ex}')
 
 app.add_middleware(
   CORSMiddleware,
@@ -90,354 +94,264 @@ def read_directory(d):
   except Exception as err:
     print(err)
     return False
-  return sorted(dlst, key=lambda x:x['name'])  + sorted(flst, key=lambda x:x['name'])
+  return sorted(dlst, key=lambda x: x['name']) + sorted(flst, key=lambda x: x['name'])
 
 
-def file_extension_check(filename):
-  return filename.split('.')[-1].lower()
-
-
-@app.get('/dir')
-async def get_directory(folderName: str):
-  #file_types = filetype.split(",")
-  files = []
-  try:
-    for p in os.scandir(folderName):
-      if not p.is_dir() and not p.is_symlink() and not p.name.startswith('.'):
-        #ext = file_extension_check(p.name)
-        #if ext in file_types:
-        files.append(p.name)
-  except Exception as err:
-    files = []
-  return files
-
+# ─── REST API endpoints ────────────────────────────────────────────────────────
 
 @app.get('/', response_class=HTMLResponse)
 async def read_root(request: Request):
   return templates.TemplateResponse("index.html", {"request": request})
 
-@app.get("/download")
-async def download_item(filename: str):
-  full_path = os.path.join(PATH, filename)
 
-  # 보호 디렉토리 체크
-  if is_protect(full_path):
-    await socket_manager.emit('update', {'dialog': '파일 다운로드 오류: 보호 디렉토리입니다.'})
-    return JSONResponse(content={'error': '파일 다운로드 오류: 보호 디렉토리입니다.'}, status_code=403)
-
-  # 존재 여부 체크
-  if not os.path.exists(full_path):
-    raise JSONResponse(content={'error':"파일 또는 폴더를 찾을 수 없습니다."}, status_code=404)
-
-  # 파일인 경우: 그대로 다운로드
-  if os.path.isfile(full_path):
-    return FileResponse(full_path, filename=filename)
-
-  # 폴더인 경우: /tmp/download.zip 로 압축 후 다운로드 (매번 새로 생성)
-  elif os.path.isdir(full_path):
-    zip_path = "/tmp/download.zip"
-
-    # 기존 압축 파일이 있다면 삭제
-    if os.path.exists(zip_path):
-      os.remove(zip_path)
-
-    # shutil.make_archive는 base_name 인자로 확장자 없는 경로를 요구함
-    base_name = "/tmp/download"  # 결과적으로 /tmp/download.zip 생성됨
-    shutil.make_archive(base_name, 'zip', root_dir=full_path)
-
-    return FileResponse(zip_path, media_type="application/zip", filename="download.zip")
-
-  else:
-    raise JSONResponse(content={'error':"올바른 파일 또는 폴더가 아닙니다."}, status_code=403)
-
-@app.post('/upload')
-async def upload_file(files: List[UploadFile] = File(...)):
-  if is_protect(PATH):
-    await socket_manager.emit('update', {'dialog': '파일 업로드 오류: 보호 디렉토리입니다.'})
-    return JSONResponse(content={'error': '파일 업로드 오류: 보호 디렉토리입니다.'}, status_code=403)
-  for file in files:
-    file_location = os.path.join(PATH, file.filename)
-    with open(file_location, "wb") as f:
-      content = await file.read()
-      f.write(content)
-  # Update file manager
-  directory_data = read_directory(PATH)
-  await socket_manager.emit('update_file_manager', {'data': directory_data})
-  try:
-    shutil.chown(PATH, user='pi', group='pi')
-  except Exception as err:
-    print(err)
-  return JSONResponse(content={"message": "파일 업로드 완료"}, status_code=200)
-
-
-@app.post('/show')
-async def show_file(data: UploadFile = File(...)):
-  try:
-    tmp_path = '/home/pi/.tmp.jpg'
-    with open(tmp_path, 'wb') as f:
-      content = await data.read()
-      f.write(content)
-    with open(tmp_path, 'rb') as f:
-      image_data = f.read()
-      encoded_image = base64.b64encode(image_data).decode('utf-8')
-      await socket_manager.emit('update', {'image': encoded_image, 'filepath': tmp_path})
-  except Exception as err:
-    print(err)
-    await socket_manager.emit('update', {'dialog': f'보기 오류: {str(err)}'})
-  return JSONResponse(content={"message": "이미지 표시 완료"}, status_code=200)
-
-@app.sio.on('connection')
-async def handle_connection(sid, *args, **kwargs):
-  pass  # Placeholder for any connection initialization
-
-@app.sio.on('init')
-async def handle_init(sid):
+@app.get('/api/init')
+async def api_init():
   global codeText, codePath
+  system_info = []
   try:
-    system_info = subprocess.check_output(['/home/pi/openpibo-os/system/system.sh']).decode().strip().split(',')
-    await app.sio.emit('system', system_info)
+    system_info = subprocess.check_output(
+      ['/home/pi/openpibo-os/system/system.sh']
+    ).decode().strip().split(',')
   except Exception as err:
     print(err)
-    await app.sio.emit('update', {'dialog': '초기화: 시스템 파일 오류입니다.'})
-
   try:
     with open(codePath, 'r') as f:
       codeText = f.read()
-  except Exception as err:
+  except Exception:
     codeText = ''
-  await app.sio.emit('init', {'codepath': codePath, 'codetext': codeText, 'path': PATH})
-
-@app.get('/tools')
-async def classifier(enable: str):
-  # print("Eanable tools:", enable)
-  if False:
-    return HTMLResponse(content="", status_code=200)
-  if enable == "on":
-    subprocess.Popen(['systemctl', 'stop', 'classify.service'])
-    subprocess.Popen(['systemctl', 'stop', 'llama-server.service'])
-    subprocess.Popen(['systemctl', 'start', 'tools.service'])
-  elif enable == "off":
-    subprocess.Popen(['systemctl', 'stop', 'tools.service'])
-  return HTMLResponse(content="", status_code=200)
-
-@app.get('/classifier')
-async def classifier(enable: str):
-  # print("Eanable classifier:", enable)
-  if False:
-    return HTMLResponse(content="", status_code=200)
-  if enable == "on":
-    subprocess.Popen(['systemctl', 'stop', 'tools.service'])
-    subprocess.Popen(['systemctl', 'stop', 'llama-server.service'])
-    subprocess.Popen(['systemctl', 'start', 'classify.service'])
-  elif enable == "off":
-    subprocess.Popen(['systemctl', 'stop', 'classify.service'])
-  return HTMLResponse(content="", status_code=200)
-
-@app.get('/llm')
-async def classifier(enable: str):
-  # print("Eanable llm:", enable)
-  if False:
-    return HTMLResponse(content="", status_code=200)
-  if enable == "on":
-    subprocess.Popen(['systemctl', 'stop', 'tools.service'])
-    subprocess.Popen(['systemctl', 'stop', 'classify.service'])
-    subprocess.Popen(['systemctl', 'start', 'llama-server.service'])
-  elif enable == "off":
-    subprocess.Popen(['systemctl', 'stop', 'llama-server.service'])
-  await asyncio.sleep(2)
-  return HTMLResponse(content="", status_code=200)
-
-@app.sio.on('reset_log')
-async def handle_reset_log(sid):
-  global record
-  record = f'[{datetime.datetime.now()}]: \n\n'
-  subprocess.Popen([f'{ENV_PATH}/python3', '/home/pi/openpibo-os/system/network_disp.py'])
-  subprocess.Popen(['servo', 'init'])
+  return JSONResponse(content={
+    'codepath': codePath,
+    'codetext': codeText,
+    'path': PATH,
+    'system': system_info,
+  })
 
 
-@app.sio.on('poweroff')
-async def handle_poweroff(sid):
-  os.system('echo "#11:!" > /dev/ttyS0')
-  subprocess.Popen(['shutdown', '-h', 'now'])
+@app.get('/api/system_status')
+async def api_system_status():
+  result = {}
+  try:
+    system_info = subprocess.check_output(
+      ['/home/pi/openpibo-os/system/system.sh']
+    ).decode().strip().split(',')
+    result['system'] = system_info
+  except Exception:
+    pass
+  try:
+    result['battery'] = requests.get(
+      'http://127.0.0.1:8080/device/%2315%3A%21', timeout=2
+    ).json().split(':')[1]
+  except Exception:
+    result['battery'] = '0%'
+  try:
+    result['dc'] = requests.get(
+      'http://127.0.0.1:8080/device/%2314%3A%21', timeout=2
+    ).json().split(':')[1]
+  except Exception:
+    result['dc'] = 'off'
+  return JSONResponse(content=result)
 
-@app.sio.on('restart')
-async def handle_restart(sid):
-  subprocess.Popen(['shutdown', '-r', 'now'])
+
+@app.get('/api/stream')
+async def api_stream(request: Request):
+  """SSE endpoint – clients subscribe here for real-time updates."""
+  q: asyncio.Queue = asyncio.Queue()
+  sse_clients.append(q)
+
+  async def generate():
+    try:
+      while True:
+        if await request.is_disconnected():
+          break
+        try:
+          data = await asyncio.wait_for(q.get(), timeout=30)
+          yield f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+        except asyncio.TimeoutError:
+          yield "data: {\"ping\": true}\n\n"
+    finally:
+      if q in sse_clients:
+        sse_clients.remove(q)
+
+  return StreamingResponse(
+    generate(),
+    media_type='text/event-stream',
+    headers={
+      'Cache-Control': 'no-cache',
+      'X-Accel-Buffering': 'no',
+    }
+  )
 
 
-@app.sio.on('load_directory')
-async def handle_load_directory(sid, p):
+@app.get('/dir')
+async def get_directory(folderName: str):
+  files = []
+  try:
+    for p in os.scandir(folderName):
+      if not p.is_dir() and not p.is_symlink() and not p.name.startswith('.'):
+        files.append(p.name)
+  except Exception:
+    files = []
+  return files
+
+
+@app.get('/api/load_directory')
+async def api_load_directory(p: str):
   global PATH
   res = read_directory(p)
   if res is not False:
     PATH = p
   else:
     res = read_directory(PATH)
-  await app.sio.emit('update_file_manager', {'data': res, 'path': PATH})
+  return JSONResponse(content={'data': res, 'path': PATH})
 
-@app.sio.on('view')
-async def handle_view(sid, p):
+
+@app.get('/api/view')
+async def api_view(p: str):
   try:
     with open(p, 'rb') as f:
-      data = f.read()
-      encoded_image = base64.b64encode(data).decode('utf-8')
-      await app.sio.emit('update', {'image': encoded_image, 'filepath': p})
+      encoded = base64.b64encode(f.read()).decode('utf-8')
+    return JSONResponse(content={'image': encoded, 'filepath': p})
   except Exception as err:
-    await app.sio.emit('update', {'dialog': f'보기 오류: {str(err)}'})
+    return JSONResponse(content={'error': str(err)}, status_code=500)
 
 
-@app.sio.on('play')
-async def handle_play(sid, p):
+@app.get('/api/play_file')
+async def api_play_file(p: str):
   try:
     with open(p, 'rb') as f:
-      data = f.read()
-      encoded_audio = base64.b64encode(data).decode('utf-8')
-      await app.sio.emit('update', {'audio': encoded_audio, 'filepath': p})
+      encoded = base64.b64encode(f.read()).decode('utf-8')
+    return JSONResponse(content={'audio': encoded, 'filepath': p})
   except Exception as err:
-    await app.sio.emit('update', {'dialog': f'재생 오류: {str(err)}'})
+    return JSONResponse(content={'error': str(err)}, status_code=500)
 
 
-@app.sio.on('load')
-async def handle_load(sid, p):
+@app.post('/api/load')
+async def api_load(data: dict = Body(...)):
   global codeText, codePath
-  if is_protect(p) :
-    await app.sio.emit('update', {'dialog': '파일 불러오기 오류: 보호 파일입니다.'})
-    return
+  p = data.get('path', '')
+  if is_protect(p):
+    return JSONResponse(content={'error': '파일 불러오기 오류: 보호 파일입니다.'}, status_code=403)
   try:
     with open(p, 'r') as f:
       codeText = f.read()
       codePath = p
-      await app.sio.emit('update', {'code': codeText, 'filepath': codePath})
+    return JSONResponse(content={'code': codeText, 'filepath': codePath})
   except Exception as err:
-    await app.sio.emit('update', {'dialog': f'파일 불러오기 오류: {str(err)}'})
+    return JSONResponse(content={'error': str(err)}, status_code=500)
 
 
-@app.sio.on('delete')
-async def handle_delete(sid, d):
+@app.post('/api/delete')
+async def api_delete(data: dict = Body(...)):
   global codeText, codePath
+  d = data.get('path', '')
   if is_protect(d):
-    await app.sio.emit('update', {'dialog': '파일 삭제 오류: 보호 파일입니다.'})
-    return
+    return JSONResponse(content={'error': '파일 삭제 오류: 보호 파일입니다.'}, status_code=403)
   if d == codePath:
-    codePath = ""
-    codeText = ""
+    codePath = ''
+    codeText = ''
   try:
     if os.path.isdir(d):
       shutil.rmtree(d)
     else:
       os.remove(d)
   except Exception as err:
-    print(err)
-    await app.sio.emit('update', {'dialog': '파일 삭제 오류: 파일명 파싱 에러입니다.'})
-    return
-  directory_data = read_directory(PATH)
-  await app.sio.emit('update_file_manager', {'data': directory_data})
+    return JSONResponse(content={'error': '파일 삭제 오류: 파일명 파싱 에러입니다.'}, status_code=500)
+  return JSONResponse(content={'data': read_directory(PATH)})
 
 
-@app.sio.on('rename')
-async def handle_rename(sid, d):
+@app.post('/api/rename')
+async def api_rename(data: dict = Body(...)):
   global codeText, codePath
-  oldpath = d['oldpath']
-  newpath = d['newpath']
+  oldpath = data.get('oldpath', '')
+  newpath = data.get('newpath', '')
   if is_protect(oldpath) or is_protect(newpath):
-    await app.sio.emit('update', {'dialog': '파일 이름 변경 오류: 보호 파일입니다.'})
-    return
+    return JSONResponse(content={'error': '파일 이름 변경 오류: 보호 파일입니다.'}, status_code=403)
   try:
     os.rename(oldpath, newpath)
-  except Exception as err:
-    await app.sio.emit('update', {'dialog': '파일 이름 변경 오류: 파일명 파싱 에러입니다.'})
-    return
-  directory_data = read_directory(PATH)
-  await app.sio.emit('update_file_manager', {'data': directory_data})
+  except Exception:
+    return JSONResponse(content={'error': '파일 이름 변경 오류: 파일명 파싱 에러입니다.'}, status_code=500)
+  result: dict = {'data': read_directory(PATH)}
   if oldpath == codePath:
     try:
       with open(newpath, 'r') as f:
         codeText = f.read()
         codePath = newpath
-        await app.sio.emit('update', {'code': codeText, 'filepath': codePath})
+      result['code'] = codeText
+      result['filepath'] = codePath
     except Exception as err:
-      await app.sio.emit('update', {'dialog': f'파일 불러오기 오류: {str(err)}'})
+      return JSONResponse(content={'error': str(err)}, status_code=500)
+  return JSONResponse(content=result)
 
-@app.sio.on('restore')
-async def handle_restore(sid):
-    try:
-        os.system("rm -rf /home/pi/code/*")
-        os.system("rm -rf /home/pi/myimage/*")
-        os.system("rm -rf /home/pi/mymodel/*")
-        os.system("rm -rf /home/pi/myaudio/*")
-        os.system("rm -rf /home/pi/examples/*")
-        os.system("cp -rf /home/pi/openpibo-os/examples/* /home/pi/examples/")
-        os.system("sudo /home/pi/openpibo-os/system/conwifi.sh wpa-psk 'pibo' '!pibo0314'")
-        os.system('echo "#11:!" > /dev/ttyS0')
-        subprocess.Popen(['shutdown', '-h', 'now'])
-    except Exception as e:
-        await sio.emit('update', {'dialog': f'초기화 오류: {str(e)}'}, room=sid)
 
-@app.sio.on('add_file')
-async def handle_add_file(sid, p):
+@app.post('/api/add_file')
+async def api_add_file(data: dict = Body(...)):
   global codeText, codePath
+  p = data.get('path', '')
   if is_protect(PATH):
-    await app.sio.emit('update', {'dialog': '파일 생성 오류: 보호 디렉토리입니다.'})
-    return
+    return JSONResponse(content={'error': '파일 생성 오류: 보호 디렉토리입니다.'}, status_code=403)
   if not os.path.exists(p):
     try:
       os.makedirs(os.path.dirname(p), exist_ok=True)
       open(p, 'a').close()
       shutil.chown(os.path.dirname(p), user='pi', group='pi')
-      directory_data = read_directory(PATH)
-      await app.sio.emit('update_file_manager', {'data': directory_data})
     except Exception as err:
-      await app.sio.emit('update', {'dialog': f'파일 생성 오류: {str(err)}'})
-      return
+      return JSONResponse(content={'error': str(err)}, status_code=500)
   codePath = p
   try:
     with open(p, 'r') as f:
       codeText = f.read()
-      await app.sio.emit('update', {'code': codeText, 'filepath': p})
+    return JSONResponse(content={
+      'code': codeText,
+      'filepath': p,
+      'data': read_directory(PATH),
+    })
   except Exception as err:
-    await app.sio.emit('update', {'dialog': f'파일 불러오기 오류: {str(err)}'})
+    return JSONResponse(content={'error': str(err)}, status_code=500)
 
-@app.sio.on('add_directory')
-async def handle_add_directory(sid, p):
+
+@app.post('/api/add_directory')
+async def api_add_directory(data: dict = Body(...)):
+  p = data.get('path', '')
   if is_protect(PATH):
-    await app.sio.emit('update', {'dialog': '디렉토리 생성 오류: 보호 폴더입니다.'})
-    return
+    return JSONResponse(content={'error': '디렉토리 생성 오류: 보호 폴더입니다.'}, status_code=403)
   try:
     os.makedirs(p, exist_ok=True)
     shutil.chown(p, user='pi', group='pi')
-    directory_data = read_directory(PATH)
-    await app.sio.emit('update_file_manager', {'data': directory_data})
+    return JSONResponse(content={'data': read_directory(PATH)})
   except Exception as err:
-    await app.sio.emit('update', {'dialog': f'디렉토리 생성 오류: {str(err)}'})
+    return JSONResponse(content={'error': str(err)}, status_code=500)
 
-@app.sio.on('save')
-async def handle_save(sid, d):
+
+@app.post('/api/save')
+async def api_save(data: dict = Body(...)):
   global codeText, codePath
   try:
-    if is_protect(d['codepath']) or is_protect(os.path.dirname(d['codepath'])):
-      await app.sio.emit('update', {'dialog': '파일 저장 오류: 보호 파일입니다.'})
-      return
-    codeText = d['codetext']
-    codePath = d['codepath']
+    cp = data['codepath']
+    if is_protect(cp) or is_protect(os.path.dirname(cp)):
+      return JSONResponse(content={'error': '파일 저장 오류: 보호 파일입니다.'}, status_code=403)
+    codeText = data['codetext']
+    codePath = cp
     os.makedirs(os.path.dirname(codePath), exist_ok=True)
     with open(codePath, 'w') as f:
       f.write(codeText)
     shutil.chown(os.path.dirname(codePath), user='pi', group='pi')
+    return JSONResponse(content={'ok': True})
   except Exception as err:
-    await app.sio.emit('update', {'dialog': f'파일 저장 오류: {str(err)}'})
+    return JSONResponse(content={'error': str(err)}, status_code=500)
 
-async def execute(EXEC, codepath):
+
+async def run_execute(EXEC: str, codepath: str):
   global record, ps
   async with mutex:
     record = f'[{datetime.datetime.now()}]: \n\n'
-    await app.sio.emit('update', {'record': record})
+    await broadcast({'record': record})
     if EXEC == 'python3':
       ps = await asyncio.create_subprocess_exec(
         f"{ENV_PATH}/{EXEC}", '-u', codepath,
         cwd=PATH,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-        stdin=asyncio.subprocess.PIPE
+        stdin=asyncio.subprocess.PIPE,
       )
     else:
       ps = await asyncio.create_subprocess_exec(
@@ -445,40 +359,36 @@ async def execute(EXEC, codepath):
         cwd=PATH,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-        stdin=asyncio.subprocess.PIPE
+        stdin=asyncio.subprocess.PIPE,
       )
     while True:
       line = await ps.stdout.readline()
       if not line:
         break
       record += line.decode()
-      await app.sio.emit('update', {'record': record})
-
+      await broadcast({'record': record})
     err = await ps.stderr.read()
     if err:
       record += f'\n{err.decode()}'
-      await app.sio.emit('update', {'record': record})
-
+      await broadcast({'record': record})
     await ps.wait()
-    ps = None  # 프로세스가 종료되었으므로 ps를 None으로 설정
-    record += "\n종료됨."
-    await app.sio.emit('update', {'record': record, 'exit': True})
-    directory_data = read_directory(PATH)
-    await app.sio.emit('update_file_manager', {'data': directory_data})
+    ps = None
+    record += '\n종료됨.'
+    await broadcast({'record': record, 'exit': True, 'file_manager': read_directory(PATH)})
 
-# execute 핸들러 수정
-@app.sio.on('execute')
-async def handle_execute(sid, d):
+
+@app.post('/api/execute')
+async def api_execute(data: dict = Body(...)):
   global codeText, codePath, ps
   subprocess.Popen(['systemctl', 'stop', 'tools.service'])
   subprocess.Popen(['systemctl', 'stop', 'classify.service'])
   subprocess.Popen(['systemctl', 'stop', 'llama-server.service'])
   try:
-    if is_protect(d['codepath']) or is_protect(os.path.dirname(d['codepath'])):
-      await app.sio.emit('update', {'dialog': '실행 오류: 보호 파일입니다.', 'exit': True})
-      return
-    codeText = d['codetext']
-    codePath = d['codepath']
+    cp = data['codepath']
+    if is_protect(cp) or is_protect(os.path.dirname(cp)):
+      return JSONResponse(content={'error': '실행 오류: 보호 파일입니다.'}, status_code=403)
+    codeText = data['codetext']
+    codePath = cp
     if ps and ps.returncode is None:
       ps.kill()
       await ps.wait()
@@ -486,13 +396,14 @@ async def handle_execute(sid, d):
     with open(codePath, 'w') as f:
       f.write(codeText)
     shutil.chown(os.path.dirname(codePath), user='pi', group='pi')
-    await execute(codeExec[d["codetype"]], codePath)
+    asyncio.create_task(run_execute(codeExec[data['codetype']], codePath))
+    return JSONResponse(content={'ok': True})
   except Exception as err:
-    await app.sio.emit('update', {'dialog': f'실행 오류: {str(err)}', 'exit': True})
+    return JSONResponse(content={'error': str(err)}, status_code=500)
 
-# executeb 핸들러 수정
-@app.sio.on('executeb')
-async def handle_executeb(sid, d):
+
+@app.post('/api/executeb')
+async def api_executeb(data: dict = Body(...)):
   global ps
   subprocess.Popen(['systemctl', 'stop', 'tools.service'])
   subprocess.Popen(['systemctl', 'stop', 'classify.service'])
@@ -501,17 +412,19 @@ async def handle_executeb(sid, d):
     if ps and ps.returncode is None:
       ps.kill()
       await ps.wait()
-    os.makedirs(os.path.dirname(d['codepath']), exist_ok=True)
-    with open(d['codepath'], 'w') as f:
-      f.write(d['codetext'])
-    shutil.chown(os.path.dirname(d['codepath']), user='pi', group='pi')
-    await execute(codeExec[d["codetype"]], d['codepath'])
+    cp = data['codepath']
+    os.makedirs(os.path.dirname(cp), exist_ok=True)
+    with open(cp, 'w') as f:
+      f.write(data['codetext'])
+    shutil.chown(os.path.dirname(cp), user='pi', group='pi')
+    asyncio.create_task(run_execute(codeExec[data['codetype']], cp))
+    return JSONResponse(content={'ok': True})
   except Exception as err:
-    await app.sio.emit('update', {'dialog': f'실행 오류: {str(err)}', 'exit': True})
+    return JSONResponse(content={'error': str(err)}, status_code=500)
 
-# stop 핸들러 수정
-@app.sio.on('stop')
-async def handle_stop(sid):
+
+@app.post('/api/stop')
+async def api_stop():
   global ps
   subprocess.Popen(['pkill', 'play'])
   subprocess.Popen(['pkill', 'llama-server'])
@@ -519,38 +432,167 @@ async def handle_stop(sid):
   if ps and ps.returncode is None:
     ps.kill()
     await ps.wait()
+  return JSONResponse(content={'ok': True})
 
-@app.sio.on('prompt')
-async def handle_prompt(sid, s):
+
+@app.post('/api/prompt')
+async def api_prompt(data: dict = Body(...)):
   global ps
   if ps and ps.stdin:
-    ps.stdin.write((s + "\n").encode())
+    ps.stdin.write((data.get('text', '') + '\n').encode())
     await ps.stdin.drain()
+  return JSONResponse(content={'ok': True})
 
-# Additional code for the periodic system status updates
+
+@app.post('/api/reset_log')
+async def api_reset_log():
+  global record
+  record = f'[{datetime.datetime.now()}]: \n\n'
+  subprocess.Popen([f'{ENV_PATH}/python3', '/home/pi/openpibo-os/system/network_disp.py'])
+  subprocess.Popen(['servo', 'init'])
+  return JSONResponse(content={'ok': True})
+
+
+@app.post('/api/poweroff')
+async def api_poweroff():
+  os.system('echo "#11:!" > /dev/ttyS0')
+  subprocess.Popen(['shutdown', '-h', 'now'])
+  return JSONResponse(content={'ok': True})
+
+
+@app.post('/api/restart')
+async def api_restart():
+  subprocess.Popen(['shutdown', '-r', 'now'])
+  return JSONResponse(content={'ok': True})
+
+
+@app.post('/api/restore')
+async def api_restore():
+  try:
+    os.system('rm -rf /home/pi/code/*')
+    os.system('rm -rf /home/pi/myimage/*')
+    os.system('rm -rf /home/pi/mymodel/*')
+    os.system('rm -rf /home/pi/myaudio/*')
+    os.system('rm -rf /home/pi/examples/*')
+    os.system('cp -rf /home/pi/openpibo-os/examples/* /home/pi/examples/')
+    os.system("sudo /home/pi/openpibo-os/system/conwifi.sh wpa-psk 'pibo' '!pibo0314'")
+    os.system('echo "#11:!" > /dev/ttyS0')
+    subprocess.Popen(['shutdown', '-h', 'now'])
+    return JSONResponse(content={'ok': True})
+  except Exception as e:
+    return JSONResponse(content={'error': str(e)}, status_code=500)
+
+
+# ─── Original REST endpoints kept as-is ───────────────────────────────────────
+
+@app.get('/download')
+async def download_item(filename: str):
+  full_path = os.path.join(PATH, filename)
+  if is_protect(full_path):
+    return JSONResponse(content={'error': '파일 다운로드 오류: 보호 디렉토리입니다.'}, status_code=403)
+  if not os.path.exists(full_path):
+    return JSONResponse(content={'error': '파일 또는 폴더를 찾을 수 없습니다.'}, status_code=404)
+  if os.path.isfile(full_path):
+    return FileResponse(full_path, filename=filename)
+  elif os.path.isdir(full_path):
+    zip_path = '/tmp/download.zip'
+    if os.path.exists(zip_path):
+      os.remove(zip_path)
+    shutil.make_archive('/tmp/download', 'zip', root_dir=full_path)
+    return FileResponse(zip_path, media_type='application/zip', filename='download.zip')
+  return JSONResponse(content={'error': '올바른 파일 또는 폴더가 아닙니다.'}, status_code=403)
+
+
+@app.post('/upload')
+async def upload_file(files: List[UploadFile] = File(...)):
+  if is_protect(PATH):
+    return JSONResponse(content={'error': '파일 업로드 오류: 보호 디렉토리입니다.'}, status_code=403)
+  for file in files:
+    file_location = os.path.join(PATH, file.filename)
+    with open(file_location, 'wb') as f:
+      f.write(await file.read())
+  directory_data = read_directory(PATH)
+  try:
+    shutil.chown(PATH, user='pi', group='pi')
+  except Exception as err:
+    print(err)
+  return JSONResponse(content={'message': '파일 업로드 완료', 'data': directory_data}, status_code=200)
+
+
+@app.post('/show')
+async def show_file(data: UploadFile = File(...)):
+  try:
+    tmp_path = '/home/pi/.tmp.jpg'
+    with open(tmp_path, 'wb') as f:
+      f.write(await data.read())
+    with open(tmp_path, 'rb') as f:
+      encoded_image = base64.b64encode(f.read()).decode('utf-8')
+    return JSONResponse(content={'image': encoded_image, 'filepath': tmp_path})
+  except Exception as err:
+    return JSONResponse(content={'error': str(err)}, status_code=500)
+
+
+@app.get('/tools')
+async def tools_service(enable: str):
+  if enable == 'on':
+    subprocess.Popen(['systemctl', 'stop', 'classify.service'])
+    subprocess.Popen(['systemctl', 'stop', 'llama-server.service'])
+    subprocess.Popen(['systemctl', 'start', 'tools.service'])
+  elif enable == 'off':
+    subprocess.Popen(['systemctl', 'stop', 'tools.service'])
+  return HTMLResponse(content='', status_code=200)
+
+
+@app.get('/classifier')
+async def classifier_service(enable: str):
+  if enable == 'on':
+    subprocess.Popen(['systemctl', 'stop', 'tools.service'])
+    subprocess.Popen(['systemctl', 'stop', 'llama-server.service'])
+    subprocess.Popen(['systemctl', 'start', 'classify.service'])
+  elif enable == 'off':
+    subprocess.Popen(['systemctl', 'stop', 'classify.service'])
+  return HTMLResponse(content='', status_code=200)
+
+
+@app.get('/llm')
+async def llm_service(enable: str):
+  if enable == 'on':
+    subprocess.Popen(['systemctl', 'stop', 'tools.service'])
+    subprocess.Popen(['systemctl', 'stop', 'classify.service'])
+    subprocess.Popen(['systemctl', 'start', 'llama-server.service'])
+  elif enable == 'off':
+    subprocess.Popen(['systemctl', 'stop', 'llama-server.service'])
+  await asyncio.sleep(2)
+  return HTMLResponse(content='', status_code=200)
+
+
+# ─── Periodic system status broadcast ─────────────────────────────────────────
+
 async def periodic_system_update():
   while True:
     try:
-      system_info = subprocess.check_output(['/home/pi/openpibo-os/system/system.sh']).decode().strip().split(',')
-      await app.sio.emit('system', system_info)
-    except Exception as err:
-      await app.sio.emit('update', {'dialog': '초기화: 시스템 파일 오류입니다.'})
-
+      system_info = subprocess.check_output(
+        ['/home/pi/openpibo-os/system/system.sh']
+      ).decode().strip().split(',')
+      await broadcast({'system': system_info})
+    except Exception:
+      pass
     try:
-      await app.sio.emit('update_battery', requests.get('http://127.0.0.1:8080/device/%2315%3A%21').json().split(':')[1])
-    except Exception as err:
-      await app.sio.emit('update_battery', '0%')
-
+      battery = requests.get(
+        'http://127.0.0.1:8080/device/%2315%3A%21', timeout=2
+      ).json().split(':')[1]
+      await broadcast({'battery': battery})
+    except Exception:
+      await broadcast({'battery': '0%'})
     try:
-      await app.sio.emit('update_dc', requests.get('http://127.0.0.1:8080/device/%2314%3A%21').json().split(':')[1])
-    except Exception as err:
-      await app.sio.emit('update_dc', 'off')
-
+      dc = requests.get(
+        'http://127.0.0.1:8080/device/%2314%3A%21', timeout=2
+      ).json().split(':')[1]
+      await broadcast({'dc': dc})
+    except Exception:
+      await broadcast({'dc': 'off'})
     await asyncio.sleep(10)
 
-#@app.on_event('startup')
-#async def on_startup():
-#  asyncio.create_task(periodic_system_update())
 
 if __name__ == '__main__':
   import argparse

--- a/ide/static/index.js
+++ b/ide/static/index.js
@@ -279,13 +279,13 @@ document.getElementById("guide_bt").addEventListener("click", function () {
 
 document.getElementById("restore_bt").addEventListener("click", async function () {
   if (await confirm_popup(translations["confirm_restore"][lang])) {
-    socket.emit("restore");
+    api('POST', '/api/restore');
   }
 });
 
 document.getElementById("poweroff_bt").addEventListener("click", async function () {
   if (await confirm_popup(translations["confirm_poweroff"][lang])) {
-      socket.emit("poweroff");
+    api('POST', '/api/poweroff');
   }
 });
 document.getElementById("logo_bt").addEventListener("click", function () {
@@ -310,7 +310,7 @@ const codeEditor = CodeMirror.fromTextArea(
         }
         saveCode = codeEditor.getValue();
         CodeMirror.signal(codeEditor, "change");
-        socket.emit("save", { codepath: $("#codepath").html(), codetext: saveCode });
+        api('POST', '/api/save', { codepath: $("#codepath").html(), codetext: saveCode });
       },
       "Ctrl-/": "toggleComment"
     },
@@ -321,7 +321,21 @@ const execute = document.getElementById("execute");
 const stop = document.getElementById("stop");
 const codeTypeBtns = document.querySelectorAll("div[name=codetype] button");
 const result = document.getElementById("result");
-const socket = io();
+
+// ── REST API helper ────────────────────────────────────────────────────────────
+async function api(method, path, data = null) {
+  const opts = { method, headers: {} };
+  if (data !== null) {
+    opts.headers['Content-Type'] = 'application/json';
+    opts.body = JSON.stringify(data);
+  }
+  const resp = await fetch(path, opts);
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throw new Error(err.error || `HTTP ${resp.status}`);
+  }
+  return resp.json();
+}
 
 let CURRENT_DIR;
 let CODE_PATH = '';
@@ -335,7 +349,8 @@ $("#fontsize").on("change", function () {
   document.getElementById("result").style.fontSize = `${$("#fontsize").val()}px`;
 });
 
-socket.on("update", async (data) => {
+// ── Central update handler (used by both SSE and direct API responses) ─────────
+async function handleUpdate(data) {
   if ("code" in data) {
     const oldpath = $("#codepath").html();
     $("#codepath").html(data["filepath"]);
@@ -405,7 +420,49 @@ socket.on("update", async (data) => {
     stop.classList.add("disabled");
     execute.disabled = false;
   }
-});
+}
+
+function handleFileManager(d) {
+  CURRENT_DIR = "path" in d ? d["path"].split("/") : CURRENT_DIR;
+  $('#path').text(CURRENT_DIR.join("/"));
+  renderFileManager(d['data']);
+}
+
+function handleSystem(data) {
+  $("#s_serial").text(data[0]);
+  $("#s_os_version").text(data[1]);
+  $("#s_runtime").text(`${Math.floor(data[2] / 3600)} hours`);
+  $("#s_cpu_temp").text(data[3]);
+  $("#s_memory").text(`${Math.floor( (data[4] - data[5]) / data[4] * 100)} %`);
+  $("#s_network").html(`<i class="fas fa-network-wired"></i> ${data[7]}, <i class="fa-solid fa-wifi"></i> ${data[6]}/${data[8]}`);
+  $("#network_info").html(`<i class="fas fa-network-wired"></i> ${data[7]}, <i class="fa-solid fa-wifi"></i> ${data[6]}/${data[8]}`);
+}
+
+function handleBattery(data) {
+  let bat = Number(data.split("%")[0]);
+  let bat_str = ['empty', 'quarter', 'half', 'three-quarters', 'full'];
+  $("#d_battery_val").html(
+    `<i class='fa fa-battery-${bat_str[Math.floor(bat / 25)]}' aria-hidden='true'></i>${data} `
+  );
+}
+
+function handleDC(data) {
+  $("#d_dc_val").html(
+    data.toUpperCase() == "ON" ? "<i class='fa fa-plug' aria-hidden='true'></i>" : ""
+  );
+}
+
+// ── SSE connection for real-time server push ───────────────────────────────────
+const es = new EventSource('/api/stream');
+es.onmessage = async (event) => {
+  const data = JSON.parse(event.data);
+  if (data.ping) return;
+  if (data.system) handleSystem(data.system);
+  if (data.battery !== undefined) handleBattery(data.battery);
+  if (data.dc !== undefined) handleDC(data.dc);
+  if ("record" in data || "exit" in data || "dialog" in data) await handleUpdate(data);
+  if (data.exit && data.file_manager) renderFileManager(data.file_manager);
+};
 
 function findBlocks(data) {
   if (data && typeof data === 'object') {
@@ -420,90 +477,80 @@ function findBlocks(data) {
     }
   }
 }
-socket.emit("init");
-socket.on("init", (d) => {
-  let filepath = d["codepath"];
-  let file_extension = filepath.substring(filepath.lastIndexOf(".") + 1, filepath.length).toLowerCase();
 
-  if (file_extension == "py") {
-    saveCode = d["codetext"];
-    codeEditor.setValue(saveCode);
+// ── Initialize IDE via REST ────────────────────────────────────────────────────
+async function initIDE() {
+  try {
+    const d = await api('GET', '/api/init');
+    handleSystem(d.system || []);
+    let filepath = d["codepath"];
+    let file_extension = filepath.substring(filepath.lastIndexOf(".") + 1, filepath.length).toLowerCase();
 
-    codeTypeBtns.forEach((el) => {
-      if (el.name == "python") el.classList.add("checked");
-      else el.classList.remove("checked");
-    });
-    $("#codepath").text(d["codepath"]);
-    $("#codeDiv").show();
-    $("#blocklyDiv").hide();
-    setLanguage(lang);
-  }
-  else {
-    try {
+    if (file_extension == "py") {
+      saveCode = d["codetext"];
+      codeEditor.setValue(saveCode);
       codeTypeBtns.forEach((el) => {
-        if (el.name == "block") el.classList.add("checked");
+        if (el.name == "python") el.classList.add("checked");
         else el.classList.remove("checked");
       });
-
-      Blockly.serialization.workspaces.load(JSON.parse(d["codetext"]), workspace);
-      workspace.scrollCenter();
-      if (d["codetext"] != "{}" && 'blocks' in JSON.parse(d["codetext"])) {
-        for (jdata of JSON.parse(d["codetext"])["blocks"]["blocks"]) {
-          findBlocks({ block: jdata })
-        }
-      }
-      saveBlock = d["codetext"];
-      update_block();
       $("#codepath").text(d["codepath"]);
+      $("#codeDiv").show();
+      $("#blocklyDiv").hide();
+      setLanguage(lang);
     }
-    catch (e) {
-      if (d["codetext"] == "") {
-        saveBlock = "{}";
-        Blockly.serialization.workspaces.load(JSON.parse("{}"), workspace);
+    else {
+      try {
+        codeTypeBtns.forEach((el) => {
+          if (el.name == "block") el.classList.add("checked");
+          else el.classList.remove("checked");
+        });
+        Blockly.serialization.workspaces.load(JSON.parse(d["codetext"]), workspace);
         workspace.scrollCenter();
+        if (d["codetext"] != "{}" && 'blocks' in JSON.parse(d["codetext"])) {
+          for (jdata of JSON.parse(d["codetext"])["blocks"]["blocks"]) {
+            findBlocks({ block: jdata })
+          }
+        }
+        saveBlock = d["codetext"];
         update_block();
         $("#codepath").text(d["codepath"]);
       }
-      else {
-        $("#codepath").html("");
+      catch (e) {
+        if (d["codetext"] == "") {
+          saveBlock = "{}";
+          Blockly.serialization.workspaces.load(JSON.parse("{}"), workspace);
+          workspace.scrollCenter();
+          update_block();
+          $("#codepath").text(d["codepath"]);
+        }
+        else {
+          $("#codepath").html("");
+        }
+      }
+      finally {
+        $("#codeDiv").hide();
+        $("#blocklyDiv").show();
+        setLanguage(lang);
+        Blockly.svgResize(workspace);
       }
     }
-    finally {
-      $("#codeDiv").hide();
-      $("#blocklyDiv").show();
-      setLanguage(lang);
-      Blockly.svgResize(workspace);
-    }
+    CURRENT_DIR = d["path"].split("/");
+    await loadDirectory(CURRENT_DIR.join("/"));
+  } catch(e) {
+    console.error("Init error:", e);
   }
+}
 
-  CURRENT_DIR = d["path"].split("/");
-  socket.emit("load_directory", CURRENT_DIR.join("/"));
-});
-
-socket.on("system", (data) => {
-  $("#s_serial").text(data[0]);
-  $("#s_os_version").text(data[1]);
-  $("#s_runtime").text(`${Math.floor(data[2] / 3600)} hours`);
-  $("#s_cpu_temp").text(data[3]);
-  $("#s_memory").text(`${Math.floor( (data[4] - data[5]) / data[4] * 100)} %`);
-  $("#s_network").html(`<i class="fas fa-network-wired"></i> ${data[7]}, <i class="fa-solid fa-wifi"></i> ${data[6]}/${data[8]}`);
-  $("#network_info").html(`<i class="fas fa-network-wired"></i> ${data[7]}, <i class="fa-solid fa-wifi"></i> ${data[6]}/${data[8]}`);
-});
-
-socket.on("update_battery", (data) => {
-  let bat = Number(data.split("%")[0]);
-  let bat_str = ['empty', 'quarter', 'half', 'three-quarters', 'full'];
-
-  $("#d_battery_val").html(
-    `<i class='fa fa-battery-${bat_str[Math.floor(bat / 25)]}' aria-hidden='true'></i>${data} `
-  );
-});
-
-socket.on("update_dc", (data) => {
-  $("#d_dc_val").html(
-    data.toUpperCase() == "ON" ? "<i class='fa fa-plug' aria-hidden='true'></i>" : ""
-  );
-});
+async function loadDirectory(p) {
+  try {
+    const d = await api('GET', `/api/load_directory?p=${encodeURIComponent(p)}`);
+    CURRENT_DIR = d.path.split("/");
+    $('#path').text(CURRENT_DIR.join("/"));
+    renderFileManager(d.data);
+  } catch(e) {
+    console.error("loadDirectory error:", e);
+  }
+}
 
 codeTypeBtns.forEach((btn) => {
   const handler = (e) => {
@@ -556,24 +603,16 @@ execute.addEventListener("click", async function () {
     if (el.classList.value.includes("checked")) codetype = el.name;
   });
   if (codetype == "block") {
-    // if (filepath.substring(filepath.lastIndexOf(".") + 1, filepath.length) != "json") {
-    //   await alert_popup("json 파일만 실행 가능합니다.");
-    //   return;
-    // }
     saveBlock = JSON.stringify(Blockly.serialization.workspaces.save(workspace))
-    socket.emit("save", {
-      codepath: filepath,
-      codetext: saveBlock
-    });
+    await api('POST', '/api/save', { codepath: filepath, codetext: saveBlock });
     update_block();
-    // for block
-    socket.emit("executeb", { codetype: "python", codepath: "/home/pi/.tmp.py", codetext: Blockly.Python.workspaceToCode(workspace) });
+    await api('POST', '/api/executeb', { codetype: "python", codepath: "/home/pi/.tmp.py", codetext: Blockly.Python.workspaceToCode(workspace) });
   }
   else {
     saveCode = codeEditor.getValue();
     codepath = $("#codepath").html();
     CodeMirror.signal(codeEditor, "change");
-    socket.emit("execute", { codetype: codetype, codepath: codepath, codetext: saveCode });
+    await api('POST', '/api/execute', { codetype: codetype, codepath: codepath, codetext: saveCode });
   }
 
   execute.classList.add("disabled");
@@ -583,25 +622,23 @@ execute.addEventListener("click", async function () {
   $("#respath").text($("#codepath").html());
 });
 
-stop.addEventListener("click", function () {
-  socket.emit("stop");
+stop.addEventListener("click", async function () {
+  await api('POST', '/api/stop');
   stop.disabled = true;
 });
 
-socket.on("update_file_manager", (d) => {
-  CURRENT_DIR = "path" in d ? d["path"].split("/") : CURRENT_DIR;
-  $('#path').text(CURRENT_DIR.join("/"));
+function renderFileManager(rawData) {
   $("#fm_table > tbody").empty();
 
   let data;
   if ($("#hiddenfile").is(":checked") == false) {
     data = [];
-    for (let i = 0; i < d['data'].length; i++)
-      if (d['data'][i].name[0] != ".")
-        data.push(d['data'][i])
+    for (let i = 0; i < rawData.length; i++)
+      if (rawData[i].name[0] != ".")
+        data.push(rawData[i])
   }
   else {
-    data = d['data'];
+    data = rawData;
   }
 
   data.unshift({ name: "..", type: "" });
@@ -626,11 +663,11 @@ socket.on("update_file_manager", (d) => {
                   return;
                 }
                 CURRENT_DIR.pop();
-                socket.emit("load_directory", CURRENT_DIR.join("/"));
+                await loadDirectory(CURRENT_DIR.join("/"));
               }
               else if (type.includes("folder")) {
                 CURRENT_DIR.push(name);
-                socket.emit("load_directory", CURRENT_DIR.join("/"));
+                await loadDirectory(CURRENT_DIR.join("/"));
               }
               else if (type.includes("file")) {
                 let ext = name.split(".");
@@ -639,10 +676,12 @@ socket.on("update_file_manager", (d) => {
 
                 if (await confirm_popup(translations['confirm_load_file'][lang](filepath)) == false) return;
                 if (["jpg", "png", "jpeg"].includes(ext.toLowerCase())) {
-                  socket.emit("view", filepath);
+                  const d = await api('GET', `/api/view?p=${encodeURIComponent(filepath)}`);
+                  await handleUpdate(d);
                 }
                 else if (["wav", "mp3"].includes(ext.toLowerCase())) {
-                  socket.emit("play", filepath);
+                  const d = await api('GET', `/api/play_file?p=${encodeURIComponent(filepath)}`);
+                  await handleUpdate(d);
                 }
                 else {
                   let codetype = "";
@@ -650,28 +689,24 @@ socket.on("update_file_manager", (d) => {
                     if (el.classList.value.includes("checked")) codetype = el.name;
                   });
                   if (codetype == "block") {
-                    // if(["json"].includes(ext.toLowerCase()) == false) {
-                    //   await alert_popup("json 파일만 로드 가능합니다.");
-                    //   return;
-                    // }
                     if (saveBlock != JSON.stringify(Blockly.serialization.workspaces.save(workspace))) {
                       if (await confirm_popup(translations['confirm_save_file'][lang]($("#codepath").html())))
-                        socket.emit("save", { codepath: $("#codepath").html(), codetext: JSON.stringify(Blockly.serialization.workspaces.save(workspace)) });
+                        await api('POST', '/api/save', { codepath: $("#codepath").html(), codetext: JSON.stringify(Blockly.serialization.workspaces.save(workspace)) });
                     }
                   }
                   else {
                     if (saveCode != codeEditor.getValue()) {
                       if (await confirm_popup(translations['confirm_save_file'][lang]($("#codepath").html())))
-                        socket.emit("save", { codepath: $("#codepath").html(), codetext: codeEditor.getValue() });
+                        await api('POST', '/api/save', { codepath: $("#codepath").html(), codetext: codeEditor.getValue() });
                     }
                   }
-                  socket.emit("load", filepath);
+                  const d = await api('POST', '/api/load', { path: filepath });
+                  await handleUpdate(d);
                 }
               }
             })
           ,
           $("<td style='width:15px;text-align:center'>").append(data[i].type == "" || data[i].protect == true ? "" : `<a href='/download?filename=${data[i].name}'><i class='fa-solid fa-circle-down'></i></a>`)
-            //$("<td style='width:15px;text-align:center'>").append(["", "folder"].includes(data[i].type) || data[i].protect==true?"":`<a href='/download?filename=${data[i].name}'><i class='fa-solid fa-circle-down'></i></a>`)
             .hover(
               function () { $(this).animate({ opacity: "0.3" }, 100); },
               function () { $(this).animate({ opacity: "1" }, 100); }
@@ -686,7 +721,6 @@ socket.on("update_file_manager", (d) => {
               if ($(this).html() == "") return;
 
               let idx = $(this).closest('tr').index();
-              //let type = $(`#fm_table tr:eq(${idx}) td:eq(0)`).html();
               let name = $(`#fm_table tr:eq(${idx}) td:eq(1)`).html();
               let newname = await prompt_popup(translations['check_newfile_name'][lang], name);
 
@@ -695,7 +729,7 @@ socket.on("update_file_manager", (d) => {
                   await alert_popup(translations['check_newfile_name'][lang]);
                   return;
                 }
-                newname = newname.trim()//.replace(/ /g, "_");
+                newname = newname.trim();
                 if (newname.length > MAX_FILENAME_LENGTH) {
                   await alert_popup(translations['name_size_limit'][lang](MAX_FILENAME_LENGTH));
                   return;
@@ -721,7 +755,9 @@ socket.on("update_file_manager", (d) => {
                 Blockly.serialization.workspaces.load(JSON.parse(saveBlock), workspace);
                 workspace.scrollCenter();
               }
-              socket.emit('rename', { oldpath: CURRENT_DIR.join("/") + "/" + name, newpath: CURRENT_DIR.join("/") + "/" + newname });
+              const d = await api('POST', '/api/rename', { oldpath: CURRENT_DIR.join("/") + "/" + name, newpath: CURRENT_DIR.join("/") + "/" + newname });
+              if (d.data) renderFileManager(d.data);
+              if (d.code !== undefined) await handleUpdate(d);
             })
           ,
           $("<td style='width:15px;text-align:center'>").append([""].includes(data[i].type) || data[i].protect == true ? "" : "<i class='fa-solid fa-trash-can'></i>")
@@ -733,7 +769,6 @@ socket.on("update_file_manager", (d) => {
               if ($(this).html() == "") return;
 
               let idx = $(this).closest('tr').index();
-              //let type = $(`#fm_table tr:eq(${idx}) td:eq(0)`).html();
               let name = $(`#fm_table tr:eq(${idx}) td:eq(1)`).html();
               if (await confirm_popup(translations['confirm_delete_file'][lang](`${CURRENT_DIR.join("/")}/${name}`))) {
                 if ($("#codepath").html().includes(CURRENT_DIR.join("/") + "/" + name)) {
@@ -750,17 +785,18 @@ socket.on("update_file_manager", (d) => {
                   Blockly.serialization.workspaces.load(JSON.parse(saveBlock), workspace);
                   workspace.scrollCenter();
                 }
-                socket.emit('delete', CURRENT_DIR.join("/") + "/" + name);
+                const d = await api('POST', '/api/delete', { path: CURRENT_DIR.join("/") + "/" + name });
+                if (d.data) renderFileManager(d.data);
               }
             })
           ,
         )
     );
   }
-});
+}
 
-$("#hiddenfile").on("change", function () {
-  socket.emit("load_directory", CURRENT_DIR.join("/"));
+$("#hiddenfile").on("change", async function () {
+  await loadDirectory(CURRENT_DIR.join("/"));
 });
 
 $("#add_directory").on("click", async function () {
@@ -776,7 +812,8 @@ $("#add_directory").on("click", async function () {
       return;
     }
 
-    socket.emit('add_directory', CURRENT_DIR.join("/") + "/" + name);
+    const d = await api('POST', '/api/add_directory', { path: CURRENT_DIR.join("/") + "/" + name });
+    if (d.data) renderFileManager(d.data);
   }
 });
 
@@ -799,9 +836,11 @@ $("#add_file").on("click", async function () {
     }
     if (saveCode != codeEditor.getValue()) {
       if (await confirm_popup(translations['confirm_save_file'][lang]($("#codepath").html())))
-        socket.emit("save", { codepath: $("#codepath").html(), codetext: codeEditor.getValue() });
+        await api('POST', '/api/save', { codepath: $("#codepath").html(), codetext: codeEditor.getValue() });
     }
-    socket.emit('add_file', CURRENT_DIR.join("/") + "/" + name);
+    const df = await api('POST', '/api/add_file', { path: CURRENT_DIR.join("/") + "/" + name });
+    if (df.data) renderFileManager(df.data);
+    if (df.code !== undefined || df.filepath !== undefined) await handleUpdate(df);
   }
 });
 
@@ -843,11 +882,11 @@ $("#upload").on("change", async (e) => {
     });
 });
 
-$("#eraser").on("click", function () {
+$("#eraser").on("click", async function () {
   result.value = "";
   $("#respath").text("");
   $("#prompt").val("");
-  socket.emit('reset_log');
+  await api('POST', '/api/reset_log');
 });
 
 window.dispatchEvent(new Event('onresize'));
@@ -902,19 +941,9 @@ $("#save").on("click", async function () {
     if (el.classList.value.includes("checked")) codetype = el.name;
   });
   if (codetype == "block") {
-    // if (filepath.substring(filepath.lastIndexOf(".") + 1, filepath.length) != "json") {
-    //   await alert_popup("json 파일만 저장 가능합니다.");
-    //   return;
-    // }
     saveBlock = JSON.stringify(Blockly.serialization.workspaces.save(workspace))
-    socket.emit("save", {
-      codepath: "/home/pi/.tmp.py",
-      codetext: Blockly.Python.workspaceToCode(workspace)
-    });
-    socket.emit("save", {
-      codepath: $("#codepath").html(),
-      codetext: saveBlock
-    });
+    await api('POST', '/api/save', { codepath: "/home/pi/.tmp.py", codetext: Blockly.Python.workspaceToCode(workspace) });
+    await api('POST', '/api/save', { codepath: $("#codepath").html(), codetext: saveBlock });
     result.value = Blockly.Python.workspaceToCode(workspace);
     update_block();
   }
@@ -922,10 +951,9 @@ $("#save").on("click", async function () {
     codeTypeBtns.forEach((el) => {
       if (el.classList.value.includes("checked")) codetype = el.name;
     });
-
     saveCode = codeEditor.getValue();
     CodeMirror.signal(codeEditor, "change");
-    socket.emit("save", { codepath: $("#codepath").html(), codetext: saveCode });
+    await api('POST', '/api/save', { codepath: $("#codepath").html(), codetext: saveCode });
   }
 });
 
@@ -1135,14 +1163,8 @@ $(document).keydown(async (evt) => {
       //   return;
       // }
       saveBlock = JSON.stringify(Blockly.serialization.workspaces.save(workspace))
-      socket.emit("save", {
-        codepath: "/home/pi/.tmp.py",
-        codetext: Blockly.Python.workspaceToCode(workspace)
-      });
-      socket.emit("save", {
-        codepath: $("#codepath").html(),
-        codetext: saveBlock
-      });
+      api('POST', '/api/save', { codepath: "/home/pi/.tmp.py", codetext: Blockly.Python.workspaceToCode(workspace) });
+      api('POST', '/api/save', { codepath: $("#codepath").html(), codetext: saveBlock });
       result.value = Blockly.Python.workspaceToCode(workspace);
       update_block();
     }
@@ -1152,7 +1174,7 @@ $(document).keydown(async (evt) => {
       });
       saveCode = codeEditor.getValue();
       CodeMirror.signal(codeEditor, "change");
-      socket.emit("save", { codepath: $("#codepath").html(), codetext: saveCode });
+      api('POST', '/api/save', { codepath: $("#codepath").html(), codetext: saveCode });
     }
     return false;
   }
@@ -1355,7 +1377,7 @@ $(document).keydown(async (evt) => {
     });
 
 window.addEventListener('beforeunload', (evt) => {
-  socket.emit("stop");
+  navigator.sendBeacon('/api/stop', JSON.stringify({}));
 });
 
 $('input[name="wifi_type_sel"]').on('click', function () {
@@ -1389,13 +1411,12 @@ $('input[name="wifi_type_sel"]').on('click', function () {
 
 $("#prompt").on("keypress", (evt) => {
   if (evt.keyCode == 13) {
-    socket.emit("prompt", $("#prompt").val().trim());
-    //$("#prompt").val("");
+    api('POST', '/api/prompt', { text: $("#prompt").val().trim() });
   }
 });
 
 $("#prompt_bt").on('click', function () {
-  socket.emit("prompt", $("#prompt").val().trim());
+  api('POST', '/api/prompt', { text: $("#prompt").val().trim() });
 });
 
 const setLanguage = (langCode) => {
@@ -1447,3 +1468,6 @@ language.addEventListener("change", function () {
 
 // warning
 document.querySelector("div.CodeMirror textarea").setAttribute("name", "ctx");
+
+// Initialize IDE
+initIDE();

--- a/ide/templates/index.html
+++ b/ide/templates/index.html
@@ -32,7 +32,6 @@
   <script src="../static/comment.js"></script>
   <script src="../static/python.js"></script>
   <script src="../static/disable-top-blocks.js"></script>
-  <script src="../static/socket.io.min.js?ver=240319v3"></script>
 </head>
 
 <body>

--- a/pibo_api/run_api.py
+++ b/pibo_api/run_api.py
@@ -1,0 +1,1211 @@
+"""
+pibo REST API Server
+Exposes all openpibo package features as REST API endpoints.
+
+Run: uvicorn run_api:app --host 0.0.0.0 --port 9000
+  or: python run_api.py
+"""
+
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from fastapi import FastAPI, Request, UploadFile, File, Body
+from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
+from contextlib import asynccontextmanager
+from typing import Optional, List
+from pydantic import BaseModel
+
+import asyncio, base64, json, logging, time
+import numpy as np
+import cv2
+import argparse
+
+
+# ── Module singletons ──────────────────────────────────────────────────────────
+_audio    = None
+_device   = None
+_motion   = None
+_oled     = None
+_speech   = None
+_dialog   = None
+_camera   = None
+_detect   = None
+_face     = None
+_classify = None
+
+def get_audio():
+    global _audio
+    if _audio is None:
+        from openpibo.audio import Audio
+        _audio = Audio()
+    return _audio
+
+def get_device():
+    global _device
+    if _device is None:
+        from openpibo.device import Device
+        _device = Device()
+    return _device
+
+def get_motion():
+    global _motion
+    if _motion is None:
+        from openpibo.motion import Motion
+        _motion = Motion()
+    return _motion
+
+def get_oled():
+    global _oled
+    if _oled is None:
+        from openpibo.oled import Oled
+        _oled = Oled()
+    return _oled
+
+def get_speech():
+    global _speech
+    if _speech is None:
+        from openpibo.speech import Speech
+        _speech = Speech()
+    return _speech
+
+def get_dialog():
+    global _dialog
+    if _dialog is None:
+        from openpibo.speech import Dialog
+        _dialog = Dialog()
+    return _dialog
+
+def get_camera():
+    global _camera
+    if _camera is None:
+        from openpibo.vision_camera import Camera
+        _camera = Camera()
+    return _camera
+
+def get_detect():
+    global _detect
+    if _detect is None:
+        from openpibo.vision_detect import Detect
+        _detect = Detect()
+    return _detect
+
+def get_face():
+    global _face
+    if _face is None:
+        from openpibo.vision_face import Face
+        _face = Face()
+    return _face
+
+def get_classify():
+    global _classify
+    if _classify is None:
+        from openpibo.vision_classify import TeachableMachine
+        _classify = TeachableMachine()
+    return _classify
+
+
+# ── Image helpers ──────────────────────────────────────────────────────────────
+def b64_to_img(b64: str) -> np.ndarray:
+    """Decode base64 string to numpy BGR image."""
+    data = base64.b64decode(b64)
+    arr  = np.frombuffer(data, np.uint8)
+    return cv2.imdecode(arr, cv2.IMREAD_COLOR)
+
+def img_to_b64(img: np.ndarray, fmt: str = '.jpg') -> str:
+    """Encode numpy BGR image to base64 string."""
+    _, buf = cv2.imencode(fmt, img)
+    return base64.b64encode(buf.tobytes()).decode()
+
+def ok(data=None):
+    body = {'result': 'ok'}
+    if data is not None:
+        body['data'] = data
+    return JSONResponse(content=body)
+
+def err(msg: str, status: int = 400):
+    return JSONResponse(content={'result': 'error', 'message': str(msg)}, status_code=status)
+
+
+# ── SSE camera stream ──────────────────────────────────────────────────────────
+_camera_stream_active = False
+_last_frame_b64: Optional[str] = None
+
+def camera_loop():
+    global _last_frame_b64, _camera_stream_active
+    cam = get_camera()
+    while _camera_stream_active:
+        try:
+            img = cam.read()
+            if img is not None:
+                _last_frame_b64 = img_to_b64(img)
+        except Exception:
+            pass
+        time.sleep(0.1)
+
+
+# ── App lifecycle ──────────────────────────────────────────────────────────────
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logging.basicConfig(level=logging.ERROR,
+                        format='%(asctime)s [%(levelname)s] %(message)s')
+    yield
+
+app = FastAPI(
+    title='pibo REST API',
+    description='REST API exposing all openpibo package features',
+    version='1.0.0',
+    lifespan=lifespan,
+)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=['*'], allow_credentials=True,
+    allow_methods=['*'], allow_headers=['*'],
+)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# AUDIO
+# ══════════════════════════════════════════════════════════════════════════════
+
+class AudioPlayBody(BaseModel):
+    filename: str
+    volume: int = 80
+    background: bool = True
+    volume2: float = 1.0
+
+class AudioRecordBody(BaseModel):
+    filename: str = '/tmp/record.wav'
+    timeout: int = 5
+    verbose: bool = True
+
+@app.post('/api/audio/play', tags=['audio'], summary='Play audio file')
+async def audio_play(body: AudioPlayBody):
+    """Play an mp3 or wav file. volume: 0-100, background: run in background."""
+    try:
+        get_audio().play(body.filename, body.volume, body.background, body.volume2)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/audio/stop', tags=['audio'], summary='Stop audio playback')
+async def audio_stop():
+    """Stop currently playing audio."""
+    try:
+        get_audio().stop()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/audio/record', tags=['audio'], summary='Record from microphone')
+async def audio_record(body: AudioRecordBody):
+    """Record audio from microphone and save to file. timeout: seconds."""
+    try:
+        get_audio().record(body.filename, body.timeout, body.verbose)
+        return ok({'filename': body.filename})
+    except Exception as e:
+        return err(e)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# COLLECT
+# ══════════════════════════════════════════════════════════════════════════════
+
+class WikiBody(BaseModel):
+    text: str
+    simple: bool = False
+
+class WeatherBody(BaseModel):
+    region: str = '전국'
+    simple: bool = False
+    search_type: str = 'forecast'
+    search_item: str = 'weather'
+
+class NewsBody(BaseModel):
+    topic: str = '뉴스랭킹'
+    simple: bool = False
+    search_type: str = 'title'
+
+@app.post('/api/collect/wikipedia', tags=['collect'], summary='Search Wikipedia')
+async def collect_wikipedia(body: WikiBody):
+    """Search Wikipedia for text.
+    simple=false returns chapter dict, simple=true returns list of strings."""
+    try:
+        from openpibo.collect import Wikipedia
+        wiki = Wikipedia()
+        if body.simple:
+            result = wiki.search_s(body.text)
+        else:
+            result = wiki.search(body.text)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/collect/weather', tags=['collect'], summary='Get weather info')
+async def collect_weather(body: WeatherBody):
+    """Get weather information for a Korean region.
+    Regions: 전국, 서울, 인천, 경기, 부산, 울산, 경남, 대구, 경북, 광주, 전남, 전북, 대전, 세종, 충남, 충북, 강원, 제주
+    simple=true: specify search_type (forecast/today/tomorrow/after_tomorrow) and search_item (weather/minimum_temp/highst_temp)"""
+    try:
+        from openpibo.collect import Weather
+        w = Weather()
+        if body.simple:
+            result = w.search_s(body.region, body.search_type, body.search_item)
+        else:
+            result = w.search(body.region)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/collect/news', tags=['collect'], summary='Get news articles')
+async def collect_news(body: NewsBody):
+    """Get news from JTBC RSS.
+    Topics: 속보, 정치, 경제, 사회, 국제, 문화, 연예, 스포츠, 뉴스랭킹, 뉴스룸 ...
+    simple=true: specify search_type (title/link/description)"""
+    try:
+        from openpibo.collect import News
+        n = News()
+        if body.simple:
+            result = n.search_s(body.topic, body.search_type)
+        else:
+            result = n.search(body.topic)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# DEVICE
+# ══════════════════════════════════════════════════════════════════════════════
+
+class EyeOnBody(BaseModel):
+    colors: list         # [R,G,B] or [R,G,B,R,G,B] or ['#rrggbb','#rrggbb']
+    hex: bool = False    # True if colors are hex strings
+    intv: int = 0        # Fade interval
+
+class DeviceCmdBody(BaseModel):
+    code: str
+    data: str = ''
+
+@app.post('/api/device/cmd', tags=['device'], summary='Send raw device command')
+async def device_cmd(body: DeviceCmdBody):
+    """Send command to device board. code can be numeric (e.g. '20') or name."""
+    try:
+        result = get_device().send_cmd(body.code, body.data)
+        return ok({'response': result})
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/device/eye/on', tags=['device'], summary='Turn on LED eyes')
+async def device_eye_on(body: EyeOnBody):
+    """Turn on LED eyes.
+    colors: [R,G,B] for both eyes, [R,G,B,R,G,B] for separate.
+    hex=true: colors is ['#rrggbb','#rrggbb'].
+    intv: fade interval (0=instant)."""
+    try:
+        dev = get_device()
+        if body.hex:
+            result = dev.eye_on_s(body.colors, body.intv)
+        else:
+            result = dev.eye_on(*body.colors, intv=body.intv)
+        return ok({'response': result})
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/device/eye/off', tags=['device'], summary='Turn off LED eyes')
+async def device_eye_off():
+    """Turn off LED eyes."""
+    try:
+        result = get_device().eye_off()
+        return ok({'response': result})
+    except Exception as e:
+        return err(e)
+
+@app.get('/api/device/battery', tags=['device'], summary='Get battery status')
+async def device_battery(v: bool = False):
+    """Get battery status. v=true returns only the value."""
+    try:
+        result = get_device().get_battery(v)
+        return ok({'battery': result})
+    except Exception as e:
+        return err(e)
+
+@app.get('/api/device/dc', tags=['device'], summary='Get DC connector status')
+async def device_dc(v: bool = False):
+    """Get DC connector status. v=true returns only the value."""
+    try:
+        result = get_device().get_dc(v)
+        return ok({'dc': result})
+    except Exception as e:
+        return err(e)
+
+@app.get('/api/device/system', tags=['device'], summary='Get system message')
+async def device_system(v: bool = False):
+    """Get system message from device. v=true returns only the value."""
+    try:
+        result = get_device().get_system(v)
+        return ok({'system': result})
+    except Exception as e:
+        return err(e)
+
+@app.get('/api/device/pir', tags=['device'], summary='Get PIR sensor value')
+async def device_pir():
+    """Get PIR (motion) sensor value."""
+    try:
+        result = get_device().get_pir()
+        return ok({'pir': result})
+    except Exception as e:
+        return err(e)
+
+@app.get('/api/device/touch', tags=['device'], summary='Get touch sensor value')
+async def device_touch():
+    """Get touch sensor value."""
+    try:
+        result = get_device().get_touch()
+        return ok({'touch': result})
+    except Exception as e:
+        return err(e)
+
+@app.get('/api/device/button', tags=['device'], summary='Get button value')
+async def device_button():
+    """Get button press value."""
+    try:
+        result = get_device().get_button()
+        return ok({'button': result})
+    except Exception as e:
+        return err(e)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MOTION
+# ══════════════════════════════════════════════════════════════════════════════
+
+class MotorBody(BaseModel):
+    n: int           # Motor index 0-9
+    pos: int         # Position -80~80
+
+class MotorsBody(BaseModel):
+    positions: List[int]      # 10 positions
+    movetime: Optional[int] = None  # milliseconds (in 50ms units)
+
+class SpeedBody(BaseModel):
+    n: int
+    speed: int       # 0-255
+
+class SpeedsBody(BaseModel):
+    speeds: List[int]  # 10 speed values
+
+class AccelBody(BaseModel):
+    n: int
+    accel: int       # 0-255
+
+class AccelsBody(BaseModel):
+    accels: List[int]  # 10 accel values
+
+class MotionPlayBody(BaseModel):
+    name: str
+    cycle: int = 1
+    path: Optional[str] = None
+
+class MotionRawBody(BaseModel):
+    exe: dict
+    cycle: int = 1
+
+@app.get('/api/motion/list', tags=['motion'], summary='Get motion list or data')
+async def motion_list(name: Optional[str] = None, path: Optional[str] = None):
+    """Get list of available motions (name=None) or specific motion data."""
+    try:
+        result = get_motion().get_motion(name, path)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/motion/motor', tags=['motion'], summary='Move single motor')
+async def motion_motor(body: MotorBody):
+    """Move single motor (n: 0-9) to position (pos: -80~80)."""
+    try:
+        get_motion().set_motor(body.n, body.pos)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/motion/motors', tags=['motion'], summary='Move all motors')
+async def motion_motors(body: MotorsBody):
+    """Move all 10 motors to specified positions. movetime in ms (50ms units)."""
+    try:
+        get_motion().set_motors(body.positions, body.movetime)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/motion/speed', tags=['motion'], summary='Set motor speed')
+async def motion_speed(body: SpeedBody):
+    """Set speed of single motor (0=slowest, 255=fastest)."""
+    try:
+        get_motion().set_speed(body.n, body.speed)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/motion/speeds', tags=['motion'], summary='Set all motor speeds')
+async def motion_speeds(body: SpeedsBody):
+    """Set speed for all 10 motors."""
+    try:
+        get_motion().set_speeds(body.speeds)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/motion/acceleration', tags=['motion'], summary='Set motor acceleration')
+async def motion_acceleration(body: AccelBody):
+    """Set acceleration for single motor (0-255)."""
+    try:
+        get_motion().set_acceleration(body.n, body.accel)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/motion/accelerations', tags=['motion'], summary='Set all motor accelerations')
+async def motion_accelerations(body: AccelsBody):
+    """Set acceleration for all 10 motors."""
+    try:
+        get_motion().set_accelerations(body.accels)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/motion/play', tags=['motion'], summary='Play named motion')
+async def motion_play(body: MotionPlayBody):
+    """Execute a named motion from profile. cycle: repetition count."""
+    try:
+        get_motion().set_motion(body.name, body.cycle, body.path)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/motion/play/raw', tags=['motion'], summary='Play raw motion data')
+async def motion_play_raw(body: MotionRawBody):
+    """Execute raw motion data dict. cycle: repetition count."""
+    try:
+        get_motion().set_motion_raw(body.exe, body.cycle)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/motion/stop', tags=['motion'], summary='Stop motion')
+async def motion_stop():
+    """Stop currently executing motion."""
+    try:
+        get_motion().stop()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# OLED
+# ══════════════════════════════════════════════════════════════════════════════
+
+class OledTextBody(BaseModel):
+    x: int
+    y: int
+    text: str
+    font: Optional[str] = None
+    size: Optional[int] = None
+
+class OledImageBody(BaseModel):
+    filename: str
+
+class OledDataBody(BaseModel):
+    image_b64: str  # base64-encoded image
+
+class OledRectBody(BaseModel):
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    fill: Optional[bool] = None
+
+class OledEllipseBody(BaseModel):
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    fill: Optional[bool] = None
+
+class OledLineBody(BaseModel):
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+
+class OledClearBody(BaseModel):
+    image: bool = True
+    fill: bool = True
+    show: bool = True
+
+@app.post('/api/oled/show', tags=['oled'], summary='Show OLED display')
+async def oled_show():
+    """Flush image buffer to OLED screen."""
+    try:
+        get_oled().show()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/oled/clear', tags=['oled'], summary='Clear OLED display')
+async def oled_clear(body: OledClearBody):
+    """Clear OLED screen and/or buffer."""
+    try:
+        get_oled().clear(body.image, body.fill, body.show)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/oled/text', tags=['oled'], summary='Draw text on OLED')
+async def oled_text(body: OledTextBody):
+    """Draw text at (x,y). Optionally set font and size before drawing."""
+    try:
+        oled = get_oled()
+        if body.font or body.size:
+            oled.set_font(body.font, body.size)
+        oled.draw_text((body.x, body.y), body.text)
+        oled.show()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/oled/image', tags=['oled'], summary='Draw image file on OLED')
+async def oled_image(body: OledImageBody):
+    """Draw PNG image file on OLED (128x64 recommended)."""
+    try:
+        oled = get_oled()
+        oled.draw_image(body.filename)
+        oled.show()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/oled/image/upload', tags=['oled'], summary='Upload and draw image on OLED')
+async def oled_image_upload(file: UploadFile = File(...)):
+    """Upload and display an image on OLED."""
+    try:
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
+            tmp.write(await file.read())
+            tmppath = tmp.name
+        oled = get_oled()
+        oled.draw_image(tmppath)
+        oled.show()
+        os.unlink(tmppath)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/oled/data', tags=['oled'], summary='Draw base64 image data on OLED')
+async def oled_data(body: OledDataBody):
+    """Draw base64-encoded image data on OLED."""
+    try:
+        img = b64_to_img(body.image_b64)
+        get_oled().draw_data(img)
+        get_oled().show()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/oled/rectangle', tags=['oled'], summary='Draw rectangle on OLED')
+async def oled_rectangle(body: OledRectBody):
+    """Draw rectangle from (x1,y1) to (x2,y2). fill=true fills it."""
+    try:
+        get_oled().draw_rectangle((body.x1, body.y1, body.x2, body.y2), body.fill)
+        get_oled().show()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/oled/ellipse', tags=['oled'], summary='Draw ellipse on OLED')
+async def oled_ellipse(body: OledEllipseBody):
+    """Draw ellipse from (x1,y1) to (x2,y2). fill=true fills it."""
+    try:
+        get_oled().draw_ellipse((body.x1, body.y1, body.x2, body.y2), body.fill)
+        get_oled().show()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/oled/line', tags=['oled'], summary='Draw line on OLED')
+async def oled_line(body: OledLineBody):
+    """Draw line from (x1,y1) to (x2,y2)."""
+    try:
+        get_oled().draw_line((body.x1, body.y1, body.x2, body.y2))
+        get_oled().show()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/oled/invert', tags=['oled'], summary='Invert OLED colors')
+async def oled_invert():
+    """Invert OLED screen colors."""
+    try:
+        get_oled().invert()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SPEECH
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TtsBody(BaseModel):
+    text: str
+    filename: str = '/tmp/tts.mp3'
+    voice: str = 'main'
+    lang: str = 'ko'
+    play: bool = True  # auto-play after TTS
+
+class SttBody(BaseModel):
+    filename: str = '/tmp/stream.wav'
+    timeout: int = 5
+    verbose: bool = True
+
+class DialogBody(BaseModel):
+    question: str
+
+class TranslateBody(BaseModel):
+    text: str
+    target: str = 'en'
+
+class DialogLoadBody(BaseModel):
+    filepath: str
+
+class NlpBody(BaseModel):
+    text: str
+    mode: str  # summary, vector, sentiment, emotion, ner, wellness, hate
+
+class LlmBody(BaseModel):
+    prompt: Optional[str] = None
+    system_prompt: Optional[str] = None
+    temperature: float = 0.8
+    max_tokens: int = 100
+
+@app.post('/api/speech/tts', tags=['speech'], summary='Text-to-Speech')
+async def speech_tts(body: TtsBody):
+    """Convert text to speech and optionally play it.
+    voices: espeak, gtts, e_gtts, main, boy, girl, man1, woman1
+    lang: ko, en"""
+    try:
+        get_speech().tts(body.text, body.filename, body.voice, body.lang)
+        if body.play:
+            get_audio().play(body.filename)
+        return ok({'filename': body.filename})
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/speech/stt', tags=['speech'], summary='Speech-to-Text')
+async def speech_stt(body: SttBody):
+    """Record audio and convert to text. timeout: seconds to record."""
+    try:
+        result = get_speech().stt(body.filename, body.timeout, body.verbose)
+        return ok({'text': result})
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/speech/dialog', tags=['speech'], summary='Get dialog response')
+async def speech_dialog(body: DialogBody):
+    """Get a response for a question from the dialog database."""
+    try:
+        result = get_dialog().get_dialog(body.question)
+        return ok({'answer': result})
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/speech/dialog/load', tags=['speech'], summary='Load dialog CSV file')
+async def speech_dialog_load(body: DialogLoadBody):
+    """Load dialog data from a CSV file (format: question,answer)."""
+    try:
+        get_dialog().load(body.filepath)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/speech/dialog/reset', tags=['speech'], summary='Reset dialog to default')
+async def speech_dialog_reset():
+    """Reset dialog database to default data."""
+    try:
+        get_dialog().reset()
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/speech/translate', tags=['speech'], summary='Translate text')
+async def speech_translate(body: TranslateBody):
+    """Translate text to target language."""
+    try:
+        result = get_dialog().translate(body.text, body.target)
+        return ok({'result': result})
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/speech/nlp', tags=['speech'], summary='NLP analysis')
+async def speech_nlp(body: NlpBody):
+    """Analyze text with deep learning.
+    modes: summary, vector, sentiment, emotion, ner, wellness, hate"""
+    try:
+        result = get_dialog().nlp_dl(body.text, body.mode)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/speech/llm', tags=['speech'], summary='Call LLM')
+async def speech_llm(body: LlmBody):
+    """Call LLM server with a prompt."""
+    try:
+        result = get_dialog().call_llm(
+            body.prompt, body.system_prompt, body.temperature, body.max_tokens
+        )
+        return ok({'response': result})
+    except Exception as e:
+        return err(e)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# CAMERA
+# ══════════════════════════════════════════════════════════════════════════════
+
+class CameraFilterBody(BaseModel):
+    image_b64: Optional[str] = None  # input image; if None, capture from camera
+    filter: str = 'none'             # none, stylization, detail, pencil, edge, flip
+    flip_flags: int = 1              # for flip: 0=vertical,1=horizontal,-1=both
+    degree: int = 10                 # for rotate
+    scale: float = 0.9              # for rotate
+
+@app.get('/api/camera/capture', tags=['camera'], summary='Capture single frame')
+async def camera_capture(format: str = 'jpg'):
+    """Capture a single frame from camera. Returns base64-encoded image."""
+    try:
+        img = get_camera().read()
+        b64 = img_to_b64(img, f'.{format}')
+        return ok({'image': b64, 'format': format})
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/camera/filter', tags=['camera'], summary='Apply image filter')
+async def camera_filter(body: CameraFilterBody):
+    """Apply a visual filter to camera capture or provided image.
+    filters: stylization, detail, pencil, edge, flip, rotate"""
+    try:
+        cam = get_camera()
+        if body.image_b64:
+            img = b64_to_img(body.image_b64)
+        else:
+            img = cam.read()
+
+        f = body.filter
+        if f == 'stylization':
+            out = cam.stylization(img)
+        elif f == 'detail':
+            out = cam.detailEnhance(img)
+        elif f == 'pencil':
+            _, out = cam.pencilSketch(img)
+        elif f == 'edge':
+            out = cam.edgePreservingFilter(img)
+        elif f == 'flip':
+            out = cam.flip(img, body.flip_flags)
+        elif f == 'rotate':
+            out = cam.rotate(img, body.degree, body.scale)
+        else:
+            out = img
+
+        return ok({'image': img_to_b64(out)})
+    except Exception as e:
+        return err(e)
+
+@app.get('/api/camera/stream', tags=['camera'], summary='MJPEG camera stream (SSE)')
+async def camera_stream(request: Request):
+    """Stream camera frames as SSE events with base64-encoded JPEG data."""
+    global _camera_stream_active, _last_frame_b64
+    import threading
+    if not _camera_stream_active:
+        _camera_stream_active = True
+        t = threading.Thread(target=camera_loop, daemon=True)
+        t.start()
+
+    async def generate():
+        global _camera_stream_active
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                if _last_frame_b64:
+                    data = json.dumps({'image': _last_frame_b64})
+                    yield f'data: {data}\n\n'
+                await asyncio.sleep(0.1)
+        finally:
+            pass
+
+    return StreamingResponse(
+        generate(),
+        media_type='text/event-stream',
+        headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'},
+    )
+
+@app.post('/api/camera/stream/stop', tags=['camera'], summary='Stop camera stream')
+async def camera_stream_stop():
+    """Stop the background camera capture loop."""
+    global _camera_stream_active
+    _camera_stream_active = False
+    return ok()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# VISION - DETECT
+# ══════════════════════════════════════════════════════════════════════════════
+
+class DetectBody(BaseModel):
+    image_b64: Optional[str] = None   # base64 image; if None, capture from camera
+    draw: bool = False                 # return annotated image
+
+class TrackerInitBody(BaseModel):
+    image_b64: Optional[str] = None
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+
+class MarkerBody(BaseModel):
+    image_b64: Optional[str] = None
+    marker_length: int = 2
+    draw: bool = False
+
+def _get_img(b64: Optional[str]) -> np.ndarray:
+    if b64:
+        return b64_to_img(b64)
+    return get_camera().read()
+
+@app.post('/api/vision/detect/object', tags=['vision-detect'], summary='Detect objects')
+async def vision_detect_object(body: DetectBody):
+    """Detect objects in image using YOLO model. Returns list of detections."""
+    try:
+        det = get_detect()
+        img = _get_img(body.image_b64)
+        items = det.detect_object(img)
+        result: dict = {'items': items}
+        if body.draw:
+            out = det.detect_object_vis(img, items)
+            result['image'] = img_to_b64(out)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/detect/qr', tags=['vision-detect'], summary='Detect QR/barcodes')
+async def vision_detect_qr(body: DetectBody):
+    """Detect QR codes and barcodes in image."""
+    try:
+        det = get_detect()
+        img = _get_img(body.image_b64)
+        items = det.detect_qr(img)
+        result: dict = {'items': items}
+        if body.draw:
+            out = det.detect_qr_vis(img, items)
+            result['image'] = img_to_b64(out)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/detect/pose', tags=['vision-detect'], summary='Detect body pose')
+async def vision_detect_pose(body: DetectBody):
+    """Detect body pose keypoints in image."""
+    try:
+        det = get_detect()
+        img = _get_img(body.image_b64)
+        items = det.detect_pose(img)
+        result: dict = {'items': items}
+        if items:
+            result['analysis'] = det.analyze_pose(items)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/detect/marker', tags=['vision-detect'], summary='Detect ArUco markers')
+async def vision_detect_marker(body: MarkerBody):
+    """Detect ArUco markers in image. marker_length: physical size in cm."""
+    try:
+        det = get_detect()
+        img = _get_img(body.image_b64)
+        items = det.detect_marker(img, body.marker_length)
+        result: dict = {'items': items}
+        if body.draw:
+            out = det.detect_marker_vis(img, items)
+            result['image'] = img_to_b64(out)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/detect/gesture', tags=['vision-detect'], summary='Detect hand gestures')
+async def vision_detect_gesture(body: DetectBody):
+    """Detect hand gestures in image."""
+    try:
+        det = get_detect()
+        img = _get_img(body.image_b64)
+        items = det.recognize_hand_gesture(img)
+        result: dict = {'items': items}
+        if body.draw:
+            out = det.recognize_hand_gesture_vis(img, items)
+            result['image'] = img_to_b64(out)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/detect/tracker/init', tags=['vision-detect'], summary='Initialize object tracker')
+async def vision_tracker_init(body: TrackerInitBody):
+    """Initialize object tracker with bounding box (x1,y1,x2,y2)."""
+    try:
+        det = get_detect()
+        img = _get_img(body.image_b64)
+        det.object_tracker_init(img, (body.x1, body.y1, body.x2, body.y2))
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/detect/tracker/update', tags=['vision-detect'], summary='Update object tracker')
+async def vision_tracker_update(body: DetectBody):
+    """Update object tracker with new frame. Returns current bounding box."""
+    try:
+        det = get_detect()
+        img = _get_img(body.image_b64)
+        bbox = det.track_object(img)
+        result: dict = {'bbox': list(bbox) if bbox else None}
+        if body.draw and bbox:
+            out = det.track_object_vis(img, bbox)
+            result['image'] = img_to_b64(out)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# VISION - FACE
+# ══════════════════════════════════════════════════════════════════════════════
+
+class FaceTrainBody(BaseModel):
+    image_b64: Optional[str] = None
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    name: str
+
+class FaceRecognizeBody(BaseModel):
+    image_b64: Optional[str] = None
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+
+class FaceAnalyzeBody(BaseModel):
+    image_b64: Optional[str] = None
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    draw: bool = False
+
+class FaceDbBody(BaseModel):
+    filename: str
+
+class FaceDeleteBody(BaseModel):
+    name: str
+
+@app.post('/api/vision/face/detect', tags=['vision-face'], summary='Detect faces')
+async def vision_face_detect(body: DetectBody):
+    """Detect faces in image. Returns list of (x1,y1,x2,y2) bounding boxes."""
+    try:
+        face = get_face()
+        img = _get_img(body.image_b64)
+        items = face.detect_face(img)
+        result: dict = {'items': items}
+        if body.draw:
+            out = face.detect_face_vis(img, items)
+            result['image'] = img_to_b64(out)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/face/analyze', tags=['vision-face'], summary='Analyze face')
+async def vision_face_analyze(body: FaceAnalyzeBody):
+    """Analyze face: returns age, gender, emotion."""
+    try:
+        face = get_face()
+        img = _get_img(body.image_b64)
+        item = (body.x1, body.y1, body.x2, body.y2)
+        result_data = face.analyze_face(img, item)
+        result: dict = {'analysis': result_data}
+        if body.draw:
+            out = face.analyze_face_vis(img, result_data)
+            result['image'] = img_to_b64(out)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/face/train', tags=['vision-face'], summary='Register a face')
+async def vision_face_train(body: FaceTrainBody):
+    """Register/train a face with a name."""
+    try:
+        face = get_face()
+        img = _get_img(body.image_b64)
+        item = (body.x1, body.y1, body.x2, body.y2)
+        result = face.train_face(img, item, body.name)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/face/recognize', tags=['vision-face'], summary='Recognize face')
+async def vision_face_recognize(body: FaceRecognizeBody):
+    """Recognize a registered face in image."""
+    try:
+        face = get_face()
+        img = _get_img(body.image_b64)
+        item = (body.x1, body.y1, body.x2, body.y2)
+        result = face.recognize(img, item)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/face/delete', tags=['vision-face'], summary='Delete registered face')
+async def vision_face_delete(body: FaceDeleteBody):
+    """Delete a registered face from the database."""
+    try:
+        result = get_face().delete_face(body.name)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.get('/api/vision/face/db', tags=['vision-face'], summary='Get face database')
+async def vision_face_db():
+    """Get list of registered faces from database."""
+    try:
+        result = get_face().get_db()
+        return ok({'db': result})
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/face/db/init', tags=['vision-face'], summary='Initialize face database')
+async def vision_face_db_init():
+    """Initialize (clear) the face database."""
+    try:
+        result = get_face().init_db()
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/face/db/save', tags=['vision-face'], summary='Save face database')
+async def vision_face_db_save(body: FaceDbBody):
+    """Save face database to file."""
+    try:
+        result = get_face().save_db(body.filename)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/face/db/load', tags=['vision-face'], summary='Load face database')
+async def vision_face_db_load(body: FaceDbBody):
+    """Load face database from file."""
+    try:
+        result = get_face().load_db(body.filename)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/face/mesh', tags=['vision-face'], summary='Detect face mesh')
+async def vision_face_mesh(body: DetectBody):
+    """Detect 3D face mesh landmarks."""
+    try:
+        face = get_face()
+        img = _get_img(body.image_b64)
+        items = face.detect_mesh(img)
+        result: dict = {'items': items}
+        if body.draw:
+            out = face.detect_mesh_vis(img, items)
+            result['image'] = img_to_b64(out)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/face/landmark', tags=['vision-face'], summary='Detect face landmarks')
+async def vision_face_landmark(body: FaceAnalyzeBody):
+    """Detect face landmarks (key points) for given face bbox."""
+    try:
+        face = get_face()
+        img = _get_img(body.image_b64)
+        item = (body.x1, body.y1, body.x2, body.y2)
+        coords = face.landmark_face(img, item)
+        result: dict = {'landmarks': coords}
+        if body.draw:
+            out = face.landmark_face_vis(img, coords)
+            result['image'] = img_to_b64(out)
+        return ok(result)
+    except Exception as e:
+        return err(e)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# VISION - CLASSIFY
+# ══════════════════════════════════════════════════════════════════════════════
+
+class ClassifyLoadBody(BaseModel):
+    model_path: str
+    label_path: str
+
+class ClassifyBody(BaseModel):
+    image_b64: Optional[str] = None
+
+@app.post('/api/vision/classify/load', tags=['vision-classify'], summary='Load classification model')
+async def vision_classify_load(body: ClassifyLoadBody):
+    """Load a TeachableMachine TFLite model on the AI-Core server."""
+    try:
+        get_classify().load(body.model_path, body.label_path)
+        return ok()
+    except Exception as e:
+        return err(e)
+
+@app.post('/api/vision/classify/predict', tags=['vision-classify'], summary='Classify image')
+async def vision_classify_predict(body: ClassifyBody):
+    """Classify image using loaded model. Returns class name and predictions."""
+    try:
+        img = _get_img(body.image_b64)
+        class_name, predictions = get_classify().predict(img)
+        return ok({'class': class_name, 'predictions': predictions})
+    except Exception as e:
+        return err(e)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# HEALTH CHECK
+# ══════════════════════════════════════════════════════════════════════════════
+
+@app.get('/api/health', tags=['system'], summary='Health check')
+async def health():
+    """Check server is running."""
+    return ok({'status': 'running'})
+
+@app.get('/', tags=['system'], summary='API info')
+async def root():
+    return JSONResponse(content={
+        'title': 'pibo REST API',
+        'version': '1.0.0',
+        'docs': '/docs',
+        'redoc': '/redoc',
+    })
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Entry point
+# ══════════════════════════════════════════════════════════════════════════════
+if __name__ == '__main__':
+    import uvicorn
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--port', type=int, default=9000)
+    args = parser.parse_args()
+    uvicorn.run('run_api:app', host=args.host, port=args.port, reload=False)

--- a/tools/lib.py
+++ b/tools/lib.py
@@ -26,9 +26,11 @@ def to_base64(im):
   return base64.b64encode(buffer).decode('utf-8')
 
 class Pibo:
-  def __init__(self, emit_func=None, logger=None):
+  def __init__(self, logger=None):
     logging.info('Class INIT')
-    self.emit = emit_func
+    # latest vision frame (updated by vision_loop, read by SSE endpoint)
+    self.last_frame_b64 = None
+    self.last_res = ''
     self.mymodel_path = "/home/pi/mymodel"
     self.trackX, self.trackY = 0, 0
     self.imgX, self.imgY = 0,0
@@ -60,7 +62,6 @@ class Pibo:
 
     self.mot.set_motors(self.motion_d, movetime=1000)
     self.det.load_hand_gesture_model()
-    asyncio.run(self.emit('onoff', True, callback=None))
     Thread(name='vision_loop', target=self.vision_loop, args=(), daemon=True).start()
 
   def vision_loop(self):
@@ -108,7 +109,8 @@ class Pibo:
       self.res_img = img.copy()
       if self.cam:
         self.cam.putText(img, '+', (self.imgX-5,self.imgY), 0.6, (100,100,200), 3)
-      asyncio.run(self.emit('stream', {'img':to_base64(img), 'data':res}, callback=None))
+      self.last_frame_b64 = to_base64(img)
+      self.last_res = res
       time.sleep(0.5)
 
   def face_detect(self):
@@ -196,6 +198,9 @@ class Pibo:
     print('marker', im.shape, self.marker_length, res)
     self.det.detect_marker_vis(im, res)
     return im, " ".join([ f'({d["id"]})-{d["distance"]}cm' for d in res])
+
+  def get_frame_b64(self):
+    return self.last_frame_b64
 
   def imwrite(self, name):
     self.cam.imwrite(name, self.res_img.copy())
@@ -399,7 +404,6 @@ class Pibo:
       item = data.split("-")
       item[2] = self.system_value[2] if item[2] == '' else item[2]
       self.system_value = item
-      asyncio.run(self.emit('update_device', self.system_value, callback=None))
 
   def device_loop(self):
     system_check_time = time.time()
@@ -454,8 +458,6 @@ class Pibo:
   # simulate
   def sim_motion(self, name, cycle=1, path=None, log=True):
     self.mot.set_motion(name, cycle, path)
-    if log == True:
-      asyncio.run(self.emit('sim_result', {'motion':'stop'}, callback=None))
 
   def async_sim_motion(self, name, cycle=1, path=None, log=True):
     self.mot.stop()
@@ -469,8 +471,6 @@ class Pibo:
   def sim_audio(self, filename, volume, log=True):
     self.stop_audio()
     self.play_audio(filename, volume, False)
-    if log == True:
-      asyncio.run(self.emit('sim_result', {'audio':'stop'}, callback=None))
 
   def async_sim_audio(self, filename, volume, log=True):
     Thread(name='sim_audio', target=self.sim_audio, args=(filename, volume, log), daemon=True).start()

--- a/tools/run_tools.py
+++ b/tools/run_tools.py
@@ -1,30 +1,26 @@
-from fastapi_socketio import SocketManager
-from fastapi import FastAPI,Request,UploadFile,File,Body
-from fastapi.responses import HTMLResponse,FileResponse,JSONResponse
+from fastapi import FastAPI, Request, UploadFile, File, Body
+from fastapi.responses import HTMLResponse, FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 
-import time,os,json,shutil,logging
-from urllib import parse
+import time, os, json, shutil, logging, asyncio
 import argparse
-from threading import Timer
 
 pibo = None
 
 def init_pibo():
   global pibo
   from lib import Pibo
-  pibo = Pibo(emit)
+  pibo = Pibo()
   os.system('/home/pi/.pyenv/bin/python3 /home/pi/openpibo-os/system/network_disp.py')
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
   logging.basicConfig(level=logging.ERROR, format='%(asctime)s [%(levelname)s] %(message)s')
-  t = Timer(0, init_pibo)
-  t.daemon = True
-  t.start()
+  loop = asyncio.get_event_loop()
+  loop.run_in_executor(None, init_pibo)
   yield
 
 try:
@@ -33,41 +29,474 @@ try:
   app.mount("/webfonts", StaticFiles(directory="webfonts"), name="webfonts")
   app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
   templates = Jinja2Templates(directory="templates")
-  socketio = SocketManager(app=app, cors_allowed_origins=[], mount_location="/socket.io", socketio_path="")
 except Exception as ex:
-  logging.error(f'Server Error:{ex}')
+  logging.error(f'Server Error: {ex}')
 
-# REST API
+
+# ── SSE broadcast ──────────────────────────────────────────────────────────────
+sse_clients: list = []
+
+async def broadcast(key: str, data):
+  msg = json.dumps({key: data}, ensure_ascii=False)
+  for q in sse_clients:
+    await q.put(msg)
+
+@app.get('/api/stream')
+async def api_stream(request: Request):
+  q: asyncio.Queue = asyncio.Queue()
+  sse_clients.append(q)
+  async def generate():
+    try:
+      while True:
+        if await request.is_disconnected():
+          break
+        try:
+          msg = await asyncio.wait_for(q.get(), timeout=30)
+          yield f"data: {msg}\n\n"
+        except asyncio.TimeoutError:
+          yield "data: {\"ping\": true}\n\n"
+    finally:
+      if q in sse_clients:
+        sse_clients.remove(q)
+  return StreamingResponse(generate(), media_type='text/event-stream',
+                           headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'})
+
+
+# ── Pages ──────────────────────────────────────────────────────────────────────
 @app.get('/', response_class=HTMLResponse)
-async def f(request:Request):
-  #await emit('onoff', False if pibo is None else True)
+async def index(request: Request):
   return templates.TemplateResponse("index.html", {"request": request})
 
-@app.post('/import_motion')
-async def import_motion(data:UploadFile = File(...)):
-  data.filename = "custom_motion.json"
 
+# ── Status ─────────────────────────────────────────────────────────────────────
+@app.get('/api/status')
+async def api_status():
+  return JSONResponse(content={'onoff': False if pibo is None else True})
+
+
+# ── Vision ─────────────────────────────────────────────────────────────────────
+@app.get('/api/vision/type')
+async def api_vision_type_get():
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  return JSONResponse(content={'vision_type': pibo.vision_type})
+
+@app.post('/api/vision/type')
+async def api_vision_type_set(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.vision_type = data.get('vision_type', 'camera')
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/vision/marker_length')
+async def api_marker_length(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.marker_length = data.get('marker_length', 2)
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/vision/tracker/init')
+async def api_tracker_init(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  if pibo.vision_type == "track":
+    pibo.object_tracker_init(data)
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/vision/pointer')
+async def api_pointer(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.imgX, pibo.imgY = data.get('x', 0), data.get('y', 0)
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/vision/sleep')
+async def api_vision_sleep(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.vision_sleep = True if data.get('sleep', 'off') == 'on' else False
+  return JSONResponse(content={'sleep': 'on' if pibo.vision_sleep else 'off'})
+
+@app.get('/api/vision/stream')
+async def api_vision_stream(request: Request):
+  """MJPEG-style SSE camera stream."""
+  async def generate():
+    import base64
+    while True:
+      if await request.is_disconnected():
+        break
+      if pibo is None or pibo.vision_sleep:
+        await asyncio.sleep(0.5)
+        continue
+      try:
+        img_b64 = pibo.get_frame_b64()
+        if img_b64:
+          data = json.dumps({'img': img_b64, 'data': pibo.last_res or ''})
+          yield f"data: {data}\n\n"
+      except Exception as ex:
+        logging.error(f'[vision_stream] {ex}')
+      await asyncio.sleep(0.5)
+  return StreamingResponse(generate(), media_type='text/event-stream',
+                           headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'})
+
+
+# ── Device ─────────────────────────────────────────────────────────────────────
+@app.get('/api/device/status')
+async def api_device_status():
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  return JSONResponse(content={'system': pibo.system_value})
+
+@app.post('/api/device/neopixel')
+async def api_neopixel(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.set_neopixel(data.get('value', [0,0,0,0,0,0]))
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/device/eye')
+async def api_eye(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  value = [0,0,0,0,0,0]
+  raw = data.get('value', '')
+  if raw:
+    value = raw.split(',')
+  pibo.set_neopixel(value)
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/device/oled/text')
+async def api_oled_text(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.set_oled(data)
+  return JSONResponse(content={'ok': True})
+
+@app.get('/api/device/oled/path')
+async def api_oled_path(p: str):
+  return JSONResponse(content={'files': os.listdir(p)})
+
+@app.post('/api/device/oled/image')
+async def api_oled_image(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.set_oled_image(data.get('path', ''))
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/device/oled/clear')
+async def api_oled_clear():
+  os.system('/home/pi/.pyenv/bin/python3 /home/pi/openpibo-os/system/network_disp.py')
+  return JSONResponse(content={'ok': True})
+
+
+# ── Audio ──────────────────────────────────────────────────────────────────────
+@app.post('/api/audio/mic')
+async def api_mic(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  await asyncio.to_thread(pibo.mic, data)
+  pibo.aud.play("/home/pi/myaudio/mic.wav", data.get('volume', 50))
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/audio/mic/replay')
+async def api_mic_replay(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.aud.play("/home/pi/myaudio/mic.wav", data.get('volume', 50))
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/audio/tts')
+async def api_tts(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  await asyncio.to_thread(pibo.tts, data)
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/audio/play')
+async def api_play_audio(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.stop_audio()
+  pibo.play_audio(data.get('filename', ''), data.get('volume', 50), True)
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/audio/stop')
+async def api_stop_audio():
+  if pibo is not None:
+    pibo.stop_audio()
+  return JSONResponse(content={'ok': True})
+
+@app.get('/api/audio/path')
+async def api_audio_path(p: str):
+  return JSONResponse(content={'files': os.listdir(p)})
+
+
+# ── Speech ─────────────────────────────────────────────────────────────────────
+@app.post('/api/speech/question')
+async def api_question(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = await asyncio.to_thread(pibo.question, data)
+  return JSONResponse(content={'answer': res, 'chat_list': list(reversed(pibo.chat_list))})
+
+@app.post('/api/speech/translate')
+async def api_translate(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = await asyncio.to_thread(pibo.translate, data)
+  return JSONResponse(content={'result': res})
+
+@app.get('/api/speech/chat_list')
+async def api_chat_list():
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  return JSONResponse(content={'chat_list': list(reversed(pibo.chat_list))})
+
+@app.post('/api/speech/reset_csv')
+async def api_reset_csv(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.reset_csv(data)
+  return JSONResponse(content={'ok': True})
+
+
+# ── Motion ─────────────────────────────────────────────────────────────────────
+@app.get('/api/motion/info')
+async def api_motion_info():
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pos, table, record = pibo.get_motor_info()
+  return JSONResponse(content={'pos': pos, 'table': table, 'record': record})
+
+@app.post('/api/motion/motor')
+async def api_set_motor(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.set_motor(data.get('idx', 0), data.get('pos', 0))
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/motion/motors')
+async def api_set_motors(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.set_motors(data.get('pos_lst', []))
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/motion/frame/add')
+async def api_add_frame(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = pibo.add_frame(data.get('seq', 0))
+  return JSONResponse(content={'table': res})
+
+@app.post('/api/motion/frame/delete')
+async def api_delete_frame(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = pibo.delete_frame(data.get('seq', 0))
+  return JSONResponse(content={'table': res})
+
+@app.post('/api/motion/frame/init')
+async def api_init_frame():
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = pibo.init_frame()
+  return JSONResponse(content={'table': res})
+
+@app.post('/api/motion/frame/play')
+async def api_play_frame(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.play_frame(data.get('cycle', 1))
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/motion/frame/stop')
+async def api_stop_frame():
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  pibo.stop_frame()
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/motion/add')
+async def api_add_motion(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = pibo.add_motion(data.get('name', ''))
+  return JSONResponse(content={'record': res})
+
+@app.post('/api/motion/load')
+async def api_load_motion(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = pibo.load_motion(data.get('name', ''))
+  return JSONResponse(content={'table': res})
+
+@app.post('/api/motion/delete')
+async def api_delete_motion(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = pibo.delete_motion(data.get('name', ''))
+  return JSONResponse(content={'record': res})
+
+@app.post('/api/motion/reset')
+async def api_reset_motion():
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = pibo.reset_motion()
+  return JSONResponse(content={'record': res})
+
+
+# ── Simulation ─────────────────────────────────────────────────────────────────
+@app.post('/api/simulate/play')
+async def api_sim_play(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  key = data.get('key', '')
+  content = data.get('content', '')
+  if key == 'eye':
+    pibo.set_neopixel(content)
+    return JSONResponse(content={'result': {'eye': 'stop'}})
+  elif key == 'motion':
+    if data.get('type') == 'default':
+      pibo.async_sim_motion(content, data.get('cycle', 1))
+    elif data.get('type') == 'mymotion':
+      pibo.async_sim_motion(content, data.get('cycle', 1), "/home/pi/mymotion.json")
+  elif key == 'audio':
+    pibo.async_sim_audio(data.get("type", "") + content, data.get("volume", 50))
+  elif key == 'oled':
+    if data.get('type') == 'text':
+      pibo.set_oled({'x': data.get('x', 0), 'y': data.get('y', 0), 'size': data.get('size', 20), 'text': content})
+    else:
+      pibo.set_oled_image(content)
+    return JSONResponse(content={'result': {'oled': 'stop'}})
+  elif key == 'tts':
+    pibo.tts({'text': content, 'voice_type': data.get('type', 'gtts'), 'volume': data.get('volume', 50)})
+    return JSONResponse(content={'result': {'tts': 'stop'}})
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/simulate/stop')
+async def api_sim_stop(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  d = data.get('key', '')
+  if d == 'eye':
+    pibo.set_neopixel([0,0,0,0,0,0])
+  elif d == 'motion':
+    pibo.stop_frame()
+    pibo.set_motors([0, 0, -80, 0, 0, 0, 0, 0, 80, 0])
+  elif d == 'audio':
+    pibo.stop_audio()
+  elif d == 'oled':
+    os.system('/home/pi/.pyenv/bin/python3 /home/pi/openpibo-os/system/network_disp.py')
+  elif d == 'tts':
+    pibo.stop_audio()
+  return JSONResponse(content={'ok': True})
+
+@app.get('/api/simulate/audio')
+async def api_sim_audio_list(p: str):
+  return JSONResponse(content={'files': os.listdir(p)})
+
+@app.get('/api/simulate/oled')
+async def api_sim_oled_list(p: str):
+  return JSONResponse(content={'files': os.listdir(p)})
+
+@app.get('/api/simulate/motion')
+async def api_sim_motion_list(type: str = 'default'):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  motions = pibo.mot.get_motion() if type == 'default' else pibo.mot.get_motion(path="/home/pi/mymotion.json")
+  return JSONResponse(content={'motions': motions})
+
+@app.post('/api/simulate/items/play')
+async def api_sim_play_items(data: dict = Body(...)):
+  if pibo is not None:
+    pibo.start_simulate(data.get('items', []))
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/simulate/items/stop')
+async def api_sim_stop_items():
+  if pibo is not None:
+    pibo.stop_simulate()
+  return JSONResponse(content={'ok': True})
+
+@app.post('/api/simulate/items')
+async def api_sim_add_item(data: dict = Body(...)):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = {}
+  try:
+    with open('/home/pi/mysim.json', 'rb') as f:
+      res = json.load(f)
+  except Exception:
+    pass
+  res[data['name']] = data['data']
+  with open('/home/pi/mysim.json', 'w') as f:
+    json.dump(res, f)
+  return JSONResponse(content={'ok': True})
+
+@app.delete('/api/simulate/items')
+async def api_sim_remove_item(name: str = None):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = {}
+  try:
+    with open('/home/pi/mysim.json', 'rb') as f:
+      res = json.load(f)
+  except Exception:
+    pass
+  if name and name in res:
+    del res[name]
+  with open('/home/pi/mysim.json', 'w') as f:
+    json.dump(res, f)
+  shutil.chown('/home/pi/mysim.json', 'pi', 'pi')
+  return JSONResponse(content={'ok': True})
+
+@app.get('/api/simulate/items')
+async def api_sim_list_items():
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = {}
+  try:
+    with open('/home/pi/mysim.json', 'rb') as f:
+      res = json.load(f)
+  except Exception:
+    pass
+  return JSONResponse(content={'items': list(res.keys())})
+
+@app.get('/api/simulate/item')
+async def api_sim_get_item(name: str):
+  if pibo is None:
+    return JSONResponse(content={'error': 'pibo not ready'}, status_code=503)
+  res = {}
+  try:
+    with open('/home/pi/mysim.json', 'rb') as f:
+      res = json.load(f)
+  except Exception:
+    pass
+  return JSONResponse(content={'item': res.get(name, {})})
+
+
+# ── Original REST endpoints ────────────────────────────────────────────────────
+@app.post('/import_motion')
+async def import_motion(data: UploadFile = File(...)):
+  data.filename = "custom_motion.json"
   with open(f"/home/pi/{data.filename}", 'wb') as f:
     content = await data.read()
     f.write(content)
-
   try:
     with open(f'/home/pi/{data.filename}', 'rb') as f:
       content = json.load(f)
   except Exception as ex:
     logging.error(f'[import_motion] Error: {ex}')
     pass
-
   pibo.motion_j.update(content)
   with open('/home/pi/mymotion.json', 'w') as f:
     json.dump(pibo.motion_j, f)
   shutil.chown('/home/pi/mymotion.json', 'pi', 'pi')
-
   try:
-    await emit('disp_motion', {'record':pibo.motion_j})
-    return JSONResponse(content={"filename":data.filename}, status_code=200)
+    return JSONResponse(content={"filename": data.filename, "record": pibo.motion_j}, status_code=200)
   except Exception as ex:
-    return JSONResponse(content={'result':'파일에 문제가 있습니다.'}, status_code=500)
+    return JSONResponse(content={'result': '파일에 문제가 있습니다.'}, status_code=500)
 
 @app.get('/export_motion/{name}', response_class=FileResponse)
 async def export_motion(name="all"):
@@ -76,16 +505,13 @@ async def export_motion(name="all"):
       tmp = json.load(f)
   except Exception as ex:
     logging.error(f'[export_motion] Error: {ex}')
-    return JSONResponse(content={'result':'저장된 모션이 없습니다.'}, status_code=500)
-
+    return JSONResponse(content={'result': '저장된 모션이 없습니다.'}, status_code=500)
   if name == "all":
-    j = tmp  
+    j = tmp
   elif name in tmp:
-    j = dict()
-    j[name] = tmp[name]
+    j = {name: tmp[name]}
   else:
-    return JSONResponse(content={'result':'선택한 모션이 없습니다.'}, status_code=500)
-
+    return JSONResponse(content={'result': '선택한 모션이 없습니다.'}, status_code=500)
   with open('/home/pi/.motion.json', 'w') as f:
     json.dump(j, f)
   shutil.chown('/home/pi/.motion.json', 'pi', 'pi')
@@ -97,400 +523,40 @@ async def download_img():
   return FileResponse(path="/home/pi/capture.jpg", media_type="image/jpeg", filename="capture.jpg")
 
 @app.post('/upload_oled')
-async def upload_oled(data:UploadFile = File(...)):
-  if pibo.onoff == False:
-    return JSONResponse(content={'result':'OFF 상태입니다.'}, status_code=500)
-
+async def upload_oled(data: UploadFile = File(...)):
+  if pibo is None or pibo.onoff == False:
+    return JSONResponse(content={'result': 'OFF 상태입니다.'}, status_code=500)
   data.filename = "tmp.jpg"
   filepath = f"/home/pi/{data.filename}"
   with open(filepath, 'wb') as f:
-    content = await data.read()
-    f.write(content)
+    f.write(await data.read())
   pibo.set_oled_image(filepath)
   os.remove(filepath)
-  return JSONResponse(content={"filename":data.filename}, status_code=200)
+  return JSONResponse(content={"filename": data.filename}, status_code=200)
 
 @app.post('/upload_file/{directory}')
-async def upload_file(directory="myaudio", data:UploadFile = File(...)):
+async def upload_file(directory="myaudio", data: UploadFile = File(...)):
   if directory not in ["myaudio", "myimage"]:
-    return JSONResponse(content={'result':'myaudio, myimage로 업로드만 가능합니다.'}, status_code=500)
-
+    return JSONResponse(content={'result': 'myaudio, myimage로 업로드만 가능합니다.'}, status_code=500)
   os.system(f"mkdir -p '/home/pi/{directory}'")
   filepath = f"/home/pi/{directory}/{data.filename}"
   with open(filepath, 'wb') as f:
-    content = await data.read()
-    f.write(content)
-  return JSONResponse(content={"filename":data.filename}, status_code=200)
+    f.write(await data.read())
+  return JSONResponse(content={"filename": data.filename}, status_code=200)
 
 @app.post('/upload_csv')
-async def upload_csv(data:UploadFile = File(...)):
+async def upload_csv(data: UploadFile = File(...)):
   data.filename = "mychat.csv"
   filepath = f"/home/pi/{data.filename}"
   with open(filepath, 'wb') as f:
-    content = await data.read()
-    f.write(content)
-
+    f.write(await data.read())
   res = pibo.load_csv(filepath)
   os.remove(filepath)
   if res:
     return JSONResponse(content={}, status_code=200)
   else:
-    return JSONResponse(content={'result':'csv 파일 에러'}, status_code=500)
+    return JSONResponse(content={'result': 'csv 파일 에러'}, status_code=500)
 
-## socktio
-@app.sio.on('onoff')
-async def onoff(sid, d=None):
-  await emit('onoff', False if pibo is None else True)
-
-# vision
-@app.sio.on('disp_vision')
-async def disp_vision(sid, d=None):
-  if pibo is None:
-    return
-  await emit('disp_vision', pibo.vision_type)
-
-@app.sio.on('detect')
-async def detect(sid, d=None):
-  if pibo is None:
-    return
-  pibo.vision_type=d
-
-@app.sio.on('marker_length')
-async def marker_length(sid, d=None):
-  if pibo is None:
-    return
-  pibo.marker_length=d
-
-@app.sio.on('object_tracker_init')
-async def object_tracker_init(sid, d=None):
-  if pibo is None:
-    return
-  if pibo.vision_type == "track":
-    pibo.object_tracker_init(d)
-
-@app.sio.on('update_img_pointer')
-async def update_img_pointer(sid, d=None):
-  if pibo is None:
-    return
-  pibo.imgX, pibo.imgY = d['x'], d['y']
-# device
-@app.sio.on('set_neopixel')
-async def set_neopixel(sid, d=None):
-  if pibo is None:
-    return
-  pibo.set_neopixel(d)
-
-@app.sio.on('set_oled')
-async def set_oled(sid, d=None):
-  if pibo is None:
-    return
-  pibo.set_oled(d)
-
-@app.sio.on('oled_path')
-async def oled_path(sid, d=None):
-  return await emit('oled_path', os.listdir(d))
-
-@app.sio.on('set_oled_image')
-async def set_oled_image(sid, d=None):
-  if pibo is None:
-    return
-  pibo.set_oled_image(d)
-
-@app.sio.on('clear_oled')
-async def clear_oled(sid, d=None):
-  os.system('/home/pi/.pyenv/bin/python3 /home/pi/openpibo-os/system/network_disp.py')
-
-@app.sio.on('mic')
-async def mic(sid, d=None):
-  if pibo is None:
-    return
-  pibo.mic(d)
-  await emit('mic', '')
-  pibo.aud.play("/home/pi/myaudio/mic.wav", d['volume'])
-
-@app.sio.on('mic_replay')
-async def mic_replay(sid, d=None):
-  if pibo is None:
-    return
-  pibo.aud.play("/home/pi/myaudio/mic.wav", d['volume'])
-
-@app.sio.on('tts')
-async def tts(sid, d=None):
-  if pibo is None:
-    return
-  pibo.tts(d)
-@app.sio.on('play_audio')
-async def play_audio(sid, d=None):
-  if pibo is not None:
-    pibo.stop_audio()
-    pibo.play_audio(d["filename"], d["volume"], True)
-
-@app.sio.on('stop_audio')
-async def stop_audio(sid, d=None):
-  if pibo is not None:
-    pibo.stop_audio()
-
-# speech
-@app.sio.on('question')
-async def question(sid, d=None):
-  if pibo is None:
-    return
-  res = pibo.question(d)
-  await emit('disp_speech', {'answer':res, 'chat_list':list(reversed(pibo.chat_list))})
-
-@app.sio.on('translate')
-async def translate(sid, d=None):
-  if pibo is None:
-    return
-  res = pibo.translate(d)
-  await emit('disp_translate', res)
-
-@app.sio.on('disp_speech')
-async def disp_speech(sid, d=None):
-  if pibo is None:
-    return
-  await emit('disp_speech', {'chat_list':list(reversed(pibo.chat_list))})
-
-@app.sio.on('reset_csv')
-async def reset_csv(sid, d=None):
-  if pibo is None:
-    return
-  pibo.reset_csv(d)
-
-# motion
-@app.sio.on('disp_motion')
-async def disp_motion(sid, d=None):
-  if pibo is None:
-    return
-  res = pibo.get_motor_info()
-  await emit('disp_motion', {'pos':res[0], 'table':res[1], 'record':res[2]})
-
-@app.sio.on('set_motor')
-async def set_motor(sid, d=None):
-  if pibo is None:
-    return
-  pibo.set_motor(d['idx'], d['pos'])
-
-@app.sio.on('set_motors')
-async def set_motors(sid, d=None):
-  if pibo is None:
-    return
-  pibo.set_motors(d['pos_lst'])
-
-@app.sio.on('add_frame')
-async def add_frame(sid, d=None):
-  if pibo is None:
-    return
-  res = pibo.add_frame(d)
-  await emit('disp_motion', {'table':res})
-
-@app.sio.on('delete_frame')
-async def delete_frame(sid, d=None):
-  if pibo is None:
-    return
-  res = pibo.delete_frame(d)
-  await emit('disp_motion', {'table':res})
-
-@app.sio.on('init_frame')
-async def init_frame(sid, d=None):
-  if pibo is None:
-    return
-  res = pibo.init_frame()
-  await emit('disp_motion',{'table':res})
-
-@app.sio.on('play_frame')
-async def play_frame(sid, d=None):
-  if pibo is None:
-    return
-  pibo.play_frame(d)
-
-@app.sio.on('stop_frame')
-async def stop_frame(sid, d=None):
-  if pibo is None:
-    return
-  pibo.stop_frame()
-
-@app.sio.on('add_motion')
-async def add_motion(sid, d=None):
-  if pibo is None:
-    return
-  res = pibo.add_motion(d)
-  await emit('disp_motion', {'record':res})
-
-@app.sio.on('load_motion')
-async def load_motion(sid, d=None):
-  if pibo is None:
-    return
-  res = pibo.load_motion(d)
-  await emit('disp_motion', {'table':res})
-
-@app.sio.on('delete_motion')
-async def delete_motion(sid, d=None):
-  if pibo is None:
-    return
-  res = pibo.delete_motion(d)
-  await emit('disp_motion', {'record':res})
-
-@app.sio.on('reset_motion')
-async def reset_motion(sid, d=None):
-  if pibo is None:
-    return
-  res = pibo.reset_motion()
-  await emit('disp_motion', {'record':res})
-
-@app.sio.on('vision_sleep')
-async def vision_sleep(sid, d='off'):
-  if pibo is None:
-    return
-  pibo.vision_sleep = True if d == 'on' else False
-  return await emit('vision_sleep', 'on' if pibo.vision_sleep else 'off')
-
-@app.sio.on('audio_path')
-async def audio_path(sid, d=None):
-  return await emit('audio_path', os.listdir(d))
-
-@app.sio.on('eye_update')
-async def eye_update(sid, d=None):
-  value = [0,0,0,0,0,0] if d == None else d.split(",")
-  pibo.set_neopixel(value)
-
-############################################################################################
-@app.sio.on('sim_play_item')
-async def sim_play_item(sid, d=None):
-  key = d['key']
-  content = d['content']
-  if pibo is not None:
-    if key == 'eye':
-      pibo.set_neopixel(content)
-      return await emit('sim_result', {'eye':'stop'})
-    elif key == 'motion':
-      if d['type'] == 'default':
-        pibo.async_sim_motion(content, d['cycle'])
-      if d['type'] == 'mymotion':
-        pibo.async_sim_motion(content, d['cycle'], "/home/pi/mymotion.json")
-    elif key == 'audio':
-      pibo.async_sim_audio(d["type"]+content, d["volume"])
-    elif key == 'oled':
-      if d['type'] == 'text':
-        pibo.set_oled({'x':d['x'], 'y': d['y'], 'size': d['size'], 'text': content})
-      else:
-        pibo.set_oled_image(content)
-      return await emit('sim_result', {'oled':'stop'})
-    elif key == 'tts':
-      pibo.tts({'text': content, 'voice_type': d['type'], 'volume': d['volume']})
-      return await emit('sim_result', {'tts':'stop'})
-    else:
-      return await emit('sim_result', "sim_play_item error: " + d)
-
-@app.sio.on('sim_stop_item')
-async def sim_stop_item(sid, d=None):
-  if pibo is not None:
-    if d == 'eye':
-      pibo.set_neopixel([0,0,0,0,0,0])
-    elif d == 'motion':
-      pibo.stop_frame()
-      pibo.set_motors([0, 0, -80, 0, 0, 0, 0, 0, 80, 0])
-    elif d == 'audio':
-      pibo.stop_audio()
-    elif d == 'oled':
-      os.system('/home/pi/.pyenv/bin/python3 /home/pi/openpibo-os/system/network_disp.py')
-    elif d == 'tts':
-      pibo.stop_audio()
-    return await emit('sim_result', "sim_stop_item ok")
-
-@app.sio.on('sim_update_audio')
-async def sim_update_audio(sid, d=None):
-  if pibo is not None:
-    return await emit('sim_update_audio', os.listdir(d))
-
-@app.sio.on('sim_update_oled')
-async def sim_update_oled(sid, d=None):
-  if pibo is not None:
-    return await emit('sim_update_oled', os.listdir(d))
-
-@app.sio.on('sim_update_motion')
-async def sim_update_motion(sid, d=None):
-  if pibo is not None:
-    return await emit('sim_update_motion', pibo.mot.get_motion() if d == 'default' else pibo.mot.get_motion(path="/home/pi/mymotion.json"))
-
-@app.sio.on('sim_play_items')
-async def sim_play_items(sid, d=None):
-  if pibo is not None:
-    pibo.start_simulate(d)
-
-@app.sio.on('sim_stop_items')
-async def sim_stop_items(sid, d=None):
-  if pibo is not None:
-    pibo.stop_simulate()
-
-@app.sio.on('sim_add_items')
-async def sim_add_items(sid, d=None):
-  if pibo is not None:
-    try:
-      res = {}
-      with open('/home/pi/mysim.json', 'rb') as f:
-        res = json.load(f)
-    except Exception as ex:
-      logging.error(f'[simulation] Error: {ex}')
-      pass
-
-    res[d['name']] = d['data']
-    with open('/home/pi/mysim.json', 'w') as f:
-      json.dump(res, f)
-    return await emit('sim_result', "sim_add_items ok")
-
-@app.sio.on('sim_remove_items')
-async def sim_remove_items(sid, d=None):
-  if pibo is not None:
-    res = {}
-    if d != None:
-      try:
-        res = {}
-        with open('/home/pi/mysim.json', 'rb') as f:
-          res = json.load(f)
-      except Exception as ex:
-        logging.error(f'[simulation] Error: {ex}')
-        pass
-
-      if d in res:
-        del res[d]
-
-    with open('/home/pi/mysim.json', 'w') as f:
-      json.dump(res, f)
-    shutil.chown('/home/pi/mysim.json', 'pi', 'pi')
-    return await emit('sim_result', "sim_remove_items ok")
-
-@app.sio.on('sim_load_items')
-async def sim_load_items(sid, d=None):
-  if pibo is not None:
-    try:
-      res = {}
-      with open('/home/pi/mysim.json', 'rb') as f:
-        res = json.load(f)
-    except Exception as ex:
-      logging.error(f'[simulation] Error: {ex}')
-      pass
-    return await emit('sim_load_items', [item for item in res])
-
-@app.sio.on('sim_load_item')
-async def sim_load_item(sid, d=None):
-  if pibo is not None:
-    try:
-      res = {}
-      with open('/home/pi/mysim.json', 'rb') as f:
-        res = json.load(f)
-    except Exception as ex:
-      logging.error(f'[simulation] Error: {ex}')
-      pass
-    return await emit('sim_load_item', res[d])
-############################################################################################
-
-async def emit(key, data, callback=None):
-  try:
-    logging.debug(f'{key}')
-    await app.sio.emit(key, data, callback=callback)
-  except Exception as ex:
-    logging.error(f'[emit] Error: {ex}')
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()

--- a/tools/static/index.js
+++ b/tools/static/index.js
@@ -209,40 +209,138 @@ async function prompt_popup(message, defaultValue = '') {
 document.getElementById("logo_bt").addEventListener("click", function () {
   location.href = `http://${location.hostname}`;
 });
-const socket = io(`http://${location.host}`, { path: "/socket.io" });
+
+// ── REST API helper ────────────────────────────────────────────────────────────
+async function api(method, path, data = null) {
+  const opts = { method, headers: {} };
+  if (data !== null) {
+    opts.headers['Content-Type'] = 'application/json';
+    opts.body = JSON.stringify(data);
+  }
+  const resp = await fetch(path, opts);
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throw new Error(err.error || `HTTP ${resp.status}`);
+  }
+  return resp.json();
+}
 
 const onoffVal = document.getElementById('onoff_val');
 const onoffCount = document.getElementById('onoff_count'); 
 onoffVal.innerHTML = `<i class="fas fa-toggle-off fa-sm fa-fade" style="--fa-animation-duration: 2s; --fa-fade-opacity: 0.6">&nbsp;off</i>`;
 
 let onoff_count = 0;
-let onoff_intv = setInterval(() => {
+let onoff_intv = setInterval(async () => {
   onoffCount.innerHTML = `<i style="opacity:0.6">${++onoff_count}</i>`;
+  try {
+    const d = await api('GET', '/api/status');
+    if (d.onoff === true) {
+      onoffVal.innerHTML = `<i class="fas fa-toggle-on">&nbsp;on</i>`;
+      clearInterval(onoff_intv);
+      onoffCount.innerHTML = "";
+      const info = await api('GET', '/api/motion/info');
+      dispMotion(info);
+      for (let i = 0; i < 10; i++) {
+        $("#m" + i + "_value").val(motor_default[i]);
+        $("#m" + i + "_range").val(motor_default[i]);
+      }
+      await api('POST', '/api/motion/motors', { pos_lst: motor_default });
+    }
+  } catch(e) {}
 }, 2000);
 
-//setInterval(() => {
-//  socket.emit("onoff");
-//}, 5000);
+// ── SSE for device status updates ─────────────────────────────────────────────
+const es = new EventSource('/api/stream');
+es.onmessage = (event) => {
+  const d = JSON.parse(event.data);
+  if (d.ping) return;
+};
 
-socket.on("onoff", function (data) {
-  onoffVal.innerHTML = data?
-    `<i class="fas fa-toggle-on">&nbsp;on</i>`
-    : `<i class="fas fa-toggle-off fa-sm fa-fade" style="--fa-animation-duration: 2s; --fa-fade-opacity: 0.6">&nbsp;off</i>`
-  console.log('onoff', data)
-
-  if (data == true) {
-    socket.emit("disp_motion");
-    clearInterval(onoff_intv);
-    onoffCount.innerHTML = "";
-    for (let i = 0; i < 10; i++) {
-      $("#m" + i + "_value").val(motor_default[i]);
-      $("#m" + i + "_range").val(motor_default[i]);
+// ── Camera stream via SSE ──────────────────────────────────────────────────────
+let visionES = null;
+function startVisionStream() {
+  if (visionES) visionES.close();
+  visionES = new EventSource('/api/vision/stream');
+  visionES.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+    if (data.img) {
+      $("#v_img").prop("src", `data:image/jpeg;charset=utf-8;base64,${data.img}`);
+      $("#v_result").text(data.data || '');
     }
-    socket.emit("set_motors", { pos_lst: motor_default });
-  }
-});
+  };
+}
 
-const getVisions = (socket) => {
+function dispMotion(datas) {
+  if ("pos" in datas) {
+    let data = datas["pos"];
+    for (let i = 0; i < 10; i++) {
+      $("#m" + i + "_value").val(data[i]);
+      $("#m" + i + "_range").val(data[i]);
+    }
+  }
+  if ("record" in datas) {
+    let res = [];
+    for (let name in datas["record"]) res.push(name);
+    $('#motor_record').text(res.join(', '));
+  }
+  if ("table" in datas) {
+    let data = datas["table"];
+    for (let i = 0; i < data.length; i++) {
+      if (i != 0)
+        for (let j = 0; j < 10; j++) {
+          data[i].d[j] = data[i].d[j] == 999 ? data[i - 1].d[j] : data[i].d[j];
+        }
+    }
+    $("#motor_table > tbody").empty();
+    for (let i = 0; i < data.length; i++) {
+      $("#motor_table > tbody").append(
+        $("<tr>")
+          .append(
+            $("<td>").append(data[i].seq / 1000 + " 초"),
+            $("<td>").append(data[i].d[0]),
+            $("<td>").append(data[i].d[1]),
+            $("<td>").append(data[i].d[2]),
+            $("<td>").append(data[i].d[3]),
+            $("<td>").append(data[i].d[4]),
+            $("<td>").append(data[i].d[5]),
+            $("<td>").append(data[i].d[6]),
+            $("<td>").append(data[i].d[7]),
+            $("<td>").append(data[i].d[8]),
+            $("<td>").append(data[i].d[9])
+          )
+          .hover(
+            function () { $(this).animate({ opacity: "0.5" }, 100); },
+            function () { $(this).animate({ opacity: "1" }, 100); }
+          )
+          .click(async function () {
+            let pos_lst = [];
+            let lst = $(this).children();
+            lst.each((idx) => {
+              if (idx == 0) {
+                $("#m_time_val").val(Number(lst.eq(idx).text().split(" 초")[0]));
+                return;
+              } else {
+                let val = Number(lst.eq(idx).text());
+                $("#m" + (idx - 1) + "_value").val(val);
+                $("#m" + (idx - 1) + "_range").val(val);
+                pos_lst[idx - 1] = val;
+              }
+            });
+            await api('POST', '/api/motion/motors', { pos_lst: pos_lst });
+          })
+          .dblclick(async function () {
+            let t = $(this).text().split(" 초")[0];
+            if (await confirm_popup(translations["confirm_motion_delete"][lang](t))) {
+              await api('POST', '/api/motion/frame/delete', { seq: Number(t) * 1000 });
+              $(this).remove();
+            }
+          })
+      );
+    }
+  }
+}
+
+const getVisions = () => {
   $("#v_img").on("click", (evt) => {
     let rect = evt.target.getBoundingClientRect();
     x = Math.floor(evt.clientX - rect.left);
@@ -257,7 +355,7 @@ const getVisions = (socket) => {
     x2 = x1+200>640?640:x1+200;
     y2 = y1+200>480?480:y1+200;
 
-    socket.emit("object_tracker_init", {x1:x1,y1:y1, x2:x2, y2:y2});
+    api('POST', '/api/vision/tracker/init', {x1:x1,y1:y1, x2:x2, y2:y2});
   });
 
   let img_x = 0;
@@ -278,38 +376,30 @@ const getVisions = (socket) => {
     cy = cy>480?480:cy;
 
     if (Math.abs(img_x - cx) > 10 || Math.abs(img_y - cy) > 10 ) {
-      socket.emit('update_img_pointer', {x:cx, y:cy})
+      api('POST', '/api/vision/pointer', {x:cx, y:cy})
       img_x = cx;
       img_y = cy;
     }
   });
 
-  socket.on("disp_vision", function (data) {
-    $("#v_func_type").val(data);
-  });
-
-  socket.on("stream", function (data) {
-    //console.log('stream', data)
-    $("#v_img").prop("src", `data:image/jpeg;charset=utf-8;base64,${data["img"]}`);
-    $("#v_result").text(data["data"]);
-  });
+  // Vision stream via SSE (startVisionStream() called on tab show)
   
   $("#v_func_type").change(function () {
-    socket.emit("detect", $(this).val());
+    api('POST', '/api/vision/type', {vision_type: $(this).val()});
   });
 
-  socket.emit("marker_length",  Number($('#marker_length').val()));
+  api('POST', '/api/vision/marker_length', {marker_length: Number($('#marker_length').val())});
   $('#marker_length').on("focusout keydown", function (evt) {
     if (
       evt.type == "focusout" ||
       (evt.type == "keydown" && evt.keyCode == 13)
     ) {
-      socket.emit("marker_length",  Number($('#marker_length').val()));
+      api('POST', '/api/vision/marker_length', {marker_length: Number($('#marker_length').val())});
     }
   });
 
   $('#marker_length').on("click", function (evt) {
-    socket.emit("marker_length",  Number($('#marker_length').val()));
+    api('POST', '/api/vision/marker_length', {marker_length: Number($('#marker_length').val())});
   });
 
   $("#v_capture").on("click", function () {
@@ -343,13 +433,13 @@ const getVisions = (socket) => {
     $("#m5_range").val(Number($("#v_tilt_range").val()));
     $("#m5_value").val(Number($("#v_tilt_range").val()));
     $("#v_location").text(`${$("#m4_range").val()}, ${$("#m5_range").val()}`);
-    socket.emit("set_motor", { idx: 5, pos: Number($("#v_tilt_range").val()) });
+    api('POST', '/api/motion/motor', { idx: 5, pos: Number($('#v_tilt_range').val()) });
   });
   $("#v_pan_range").on("click touchend", function (evt) {
     $("#m4_range").val(Number($("#v_pan_range").val()));
     $("#m4_value").val(Number($("#v_pan_range").val()));
     $("#v_location").text(`${$("#m4_range").val()}, ${$("#m5_range").val()}`);
-    socket.emit("set_motor", { idx: 4, pos: Number($("#v_pan_range").val()) });
+    api('POST', '/api/motion/motor', { idx: 4, pos: Number($('#v_pan_range').val()) });
   });
 
   $("#v_tilt_reset").on("click", function (evt) {
@@ -357,14 +447,14 @@ const getVisions = (socket) => {
     $("#m5_range").val(Number($("#v_tilt_range").val()));
     $("#m5_value").val(Number($("#v_tilt_range").val()));
     $("#v_location").text(`${$("#m4_range").val()}, ${$("#m5_range").val()}`);
-    socket.emit("set_motor", { idx: 5, pos: Number($("#v_tilt_range").val()) });
+    api('POST', '/api/motion/motor', { idx: 5, pos: Number($('#v_tilt_range').val()) });
   });
   $("#v_pan_reset").on("click", () => {
     $("#v_pan_range").val(0);
     $("#m4_range").val(Number($("#v_pan_range").val()));
     $("#m4_value").val(Number($("#v_pan_range").val()));
     $("#v_location").text(`${$("#m4_range").val()}, ${$("#m5_range").val()}`);
-    socket.emit("set_motor", { idx: 4, pos: Number($("#v_pan_range").val()) });
+    api('POST', '/api/motion/motor', { idx: 4, pos: Number($('#v_pan_range').val()) });
   });
 };
 
@@ -394,15 +484,17 @@ let checkOled = (x, y, size) => {
   return true;
 };
 
-const getDevices = (socket) => {
-  socket.on("update_neopixel", function (data) {
-    for (let i = 0; i < 6; i++) $("#d_n" + i + "_val").val(data[i]);
-  });
-
-  socket.on("update_device", function (data) {
-    $("#d_pir_val").text(data[0].toLowerCase());
-    $("#d_touch_val").text(data[1].toLowerCase());
-  });
+const getDevices = () => {
+  // Device status polled via REST API
+  setInterval(async () => {
+    try {
+      const d = await api('GET', '/api/device/status');
+      if (d.system) {
+        $("#d_pir_val").text((d.system[0] || '').toLowerCase());
+        $("#d_touch_val").text((d.system[1] || '').toLowerCase());
+      }
+    } catch(e) {}
+  }, 2000);
 
   for (let i = 0; i < 6; i++) {
     let tneopixel = "#d_n" + i + "_val";
@@ -420,13 +512,13 @@ const getDevices = (socket) => {
           alert(translations["range_warn"][lang](min, max));
           $(this).val(0);
         } else {
-          socket.emit("set_neopixel", { idx: i, value: val });
+          api('POST', '/api/device/neopixel', { value: { idx: i, value: val } });
         }
       }
     });
 
     $(tneopixel).on("click", function (evt) {
-      socket.emit("set_neopixel", { idx: i, value: $(this).val() });
+      api('POST', '/api/device/neopixel', { value: { idx: i, value: $(this).val() } });
     });
   }
 
@@ -437,7 +529,7 @@ const getDevices = (socket) => {
       let tneopixel = "#d_n" + i + "_val";
       $(tneopixel).val(0);
     }
-    socket.emit("eye_update", "0,0,0,0,0,0");
+    api('POST', '/api/device/eye', { value: '0,0,0,0,0,0' });
   });
 
   $("#d_otext_val").on("keydown", function (evt) {
@@ -449,7 +541,7 @@ const getDevices = (socket) => {
       let size = Number($("#d_osize_val").val());
 
       if (checkOled(x, y, size))
-        socket.emit("set_oled", { x: x, y: y, size: size, text: text });
+        api('POST', '/api/device/oled/text', { x: x, y: y, size: size, text: text });
       else
       alert(translations["oled_input_error"][lang]);
     }
@@ -465,7 +557,7 @@ const getDevices = (socket) => {
       if (text == "") return;
 
       if (checkOled(x, y, size))
-        socket.emit("set_oled", { x: x, y: y, size: size, text: text });
+        api('POST', '/api/device/oled/text', { x: x, y: y, size: size, text: text });
       else
       alert(translations["oled_input_error"][lang]);
     }
@@ -481,7 +573,7 @@ const getDevices = (socket) => {
       if (text == "") return;
 
       if (checkOled(x, y, size))
-        socket.emit("set_oled", { x: x, y: y, size: size, text: text });
+        api('POST', '/api/device/oled/text', { x: x, y: y, size: size, text: text });
       else
       alert(translations["oled_input_error"][lang]);
     }
@@ -497,7 +589,7 @@ const getDevices = (socket) => {
       if (text == "") return;
 
       if (checkOled(x, y, size))
-        socket.emit("set_oled", { x: x, y: y, size: size, text: text });
+        api('POST', '/api/device/oled/text', { x: x, y: y, size: size, text: text });
       else
         alert(translations["oled_input_error"][lang]);
     }
@@ -512,7 +604,7 @@ const getDevices = (socket) => {
     if (text == "") return;
 
     if (checkOled(x, y, size))
-      socket.emit("set_oled", { x: x, y: y, size: size, text: text });
+      api('POST', '/api/device/oled/text', { x: x, y: y, size: size, text: text });
     else
     alert(translations["oled_input_error"][lang]);
   });
@@ -538,43 +630,36 @@ const getDevices = (socket) => {
   });
 
   $("#clear_oled_bt").on("click", function () {
-    socket.emit("clear_oled");
+    api('POST', '/api/device/oled/clear');
   });
 
-  socket.on("oled_path", (data) => {
+  function updateOledFiles(data) {
     $("#oledfiles").empty();
     $("#oledfiles").append(`<option value='-'>${translations["select"][lang]}</option>`);
     for (let i = 0; i < data.length; i++) {
       let filename = data[i];
       let extension = filename.split(".")[1].toLowerCase();
-
       if (["png", "jpg"].includes(extension))
-        $("#oledfiles").append(
-          `<option value="${filename}">${filename.split(".jpg")[0]}</option>`
-        );
+        $("#oledfiles").append(`<option value="${filename}">${filename.split(".jpg")[0]}</option>`);
     }
-  });
+  }
 
-  $("#oledpath").on("change", () => {
+  $("#oledpath").on("change", async () => {
     let p = $("#oledpath").val();
     if (p != "-") {
-      socket.emit("oled_path", p);
+      const d = await api('GET', `/api/device/oled/path?p=${encodeURIComponent(p)}`);
+      updateOledFiles(d.files);
     }
   });
 
-  $("#oledfiles").on("change", () => {
+  $("#oledfiles").on("change", async () => {
     let filename = $("#oledfiles").val();
-
     if (filename != "-") {
-      socket.emit("set_oled_image", `${$("#oledpath").val()}/${filename}`);
+      await api('POST', '/api/device/oled/image', { path: `${$("#oledpath").val()}/${filename}` });
     }
   });
 
-  socket.on("mic", function (d) {
-    $("#mic_status").text(d);
-  });
-
-  $("#mic_bt").on("click", function () {
+  $("#mic_bt").on("click", async function () {
     let tmictime = "#mic_time_val";
     let val = Number($(tmictime).val());
     let min = Number($(tmictime).attr("min"));
@@ -586,52 +671,44 @@ const getDevices = (socket) => {
     }
 
     $("#mic_status").html("<i class='fa-solid fa-fade'>녹음 중</i>");
-    socket.emit("mic", {
-      time: val,
-      volume: Number($("#volume").val()),
-    });
+    await api('POST', '/api/audio/mic', { time: val, volume: Number($("#volume").val()) });
+    $("#mic_status").text('완료');
   });
 
-  $("#mic_replay_bt").on("click", function () {
-    socket.emit("mic_replay", { volume: Number($("#volume").val()) });
+  $("#mic_replay_bt").on("click", async function () {
+    await api('POST', '/api/audio/mic/replay', { volume: Number($("#volume").val()) });
   });
 
-  socket.on("audio_path", (data) => {
+  function updateAudioFiles(data) {
     $("#audiofiles").empty();
     $("#audiofiles").append(`<option value='-'>${translations["select"][lang]}</option>`);
     for (let i = 0; i < data.length; i++) {
       let filename = data[i];
       let extension = filename.split(".")[1];
-
       if (["mp3", "wav"].includes(extension))
-        $("#audiofiles").append(
-          `<option value="${filename}">${filename.split(".")[0]}</option>`
-        );
+        $("#audiofiles").append(`<option value="${filename}">${filename.split(".")[0]}</option>`);
     }
-  });
+  }
 
-  $("#audiopath").on("change", () => {
+  $("#audiopath").on("change", async () => {
     let p = $("#audiopath").val();
     if (p != "-") {
-      socket.emit("audio_path", p);
+      const d = await api('GET', `/api/audio/path?p=${encodeURIComponent(p)}`);
+      updateAudioFiles(d.files);
     }
   });
 
-  $("#play_audio_bt").on("click", function () {
+  $("#play_audio_bt").on("click", async function () {
     let filename = $("#audiofiles").val();
-
     if (filename == "-") {
       alert(translations["music_name_empty"][lang]);
       return;
     }
-    socket.emit("play_audio", {
-      filename: `${$("#audiopath").val()}/${filename}`,
-      volume: Number($("#volume").val()),
-    });
+    await api('POST', '/api/audio/play', { filename: `${$("#audiopath").val()}/${filename}`, volume: Number($("#volume").val()) });
   });
 
-  $("#stop_audio_bt").on("click", function () {
-    socket.emit("stop_audio");
+  $("#stop_audio_bt").on("click", async function () {
+    await api('POST', '/api/audio/stop');
   });
 
   $("#upload_audio").on("change", (e) => {
@@ -675,7 +752,7 @@ const getDevices = (socket) => {
   });
 };
 
-const getMotions = (socket) => {
+const getMotions = () => {
   for (let i = 0; i < 10; i++) {
     let tval = "#m" + i + "_value";
     let trange = "#m" + i + "_range";
@@ -685,7 +762,7 @@ const getMotions = (socket) => {
     });
 
     $(trange).on("click touchend", function (evt) {
-      socket.emit("set_motor", { idx: i, pos: Number($(trange).val()) });
+      api('POST', '/api/motion/motor', { idx: i, pos: Number($(trange).val()) });
     });
 
     $(tval).on("focusout keydown", async function (evt) {
@@ -702,7 +779,7 @@ const getMotions = (socket) => {
           await alert_popup(translations["range_warn"][lang](min, max));
         } else {
           $(trange).val(pos);
-          socket.emit("set_motor", { idx: i, pos: pos });
+          api('POST', '/api/motion/motor', { idx: i, pos: pos });
         }
       }
     });
@@ -710,7 +787,7 @@ const getMotions = (socket) => {
     $(tval).on("click", function (evt) {
       let pos = $(tval).val();
       $(trange).val(pos);
-      socket.emit("set_motor", { idx: i, pos: Number(pos) });
+      api('POST', '/api/motion/motor', { idx: i, pos: Number(pos) });
     });
   }
 
@@ -735,102 +812,15 @@ const getMotions = (socket) => {
       $("#m" + i + "_value").val(motor_default[i]);
       $("#m" + i + "_range").val(motor_default[i]);
     }
-    socket.emit("set_motors", { pos_lst: motor_default });
+    api('POST', '/api/motion/motors', { pos_lst: motor_default });
   });
 
   // 저장 버튼
   $("#add_frame_bt").on("click", function () {
-    socket.emit("add_frame", $("#m_time_val").val() * 1000);
+    api('POST', '/api/motion/frame/add', { seq: Number($('#m_time_val').val()) * 1000 }).then(d => dispMotion(d));
   });
 
-  socket.on("disp_motion", function (datas) {
-    // 모터 값 로드
-    if ("pos" in datas) {
-      let data = datas["pos"];
-      for (let i = 0; i < 10; i++) {
-        let tval = "#m" + i + "_value";
-        let trange = "#m" + i + "_range";
-        $(tval).val(data[i]);
-        $(trange).val(data[i]);
-      }
-    }
-
-    // json 로드
-    if ("record" in datas) {
-      let res = [];
-      for(name in datas["record"]) {
-        res.push(name);
-      }
-      $('#motor_record').text(res.join(', '));
-    }
-
-    // 테이블 로드
-    if ("table" in datas) {
-      let data = datas["table"];
-
-      for (let i = 0; i < data.length; i++) {
-        if (i != 0)
-          for (let j = 0; j < 10; j++) {
-            data[i].d[j] =
-              data[i].d[j] == 999 ? data[i - 1].d[j] : data[i].d[j];
-          }
-      }
-
-      $("#motor_table > tbody").empty();
-      for (let i = 0; i < data.length; i++) {
-        $("#motor_table > tbody").append(
-          $("<tr>")
-            .append(
-              $("<td>").append(data[i].seq / 1000 + " 초"),
-              $("<td>").append(data[i].d[0]),
-              $("<td>").append(data[i].d[1]),
-              $("<td>").append(data[i].d[2]),
-              $("<td>").append(data[i].d[3]),
-              $("<td>").append(data[i].d[4]),
-              $("<td>").append(data[i].d[5]),
-              $("<td>").append(data[i].d[6]),
-              $("<td>").append(data[i].d[7]),
-              $("<td>").append(data[i].d[8]),
-              $("<td>").append(data[i].d[9])
-            )
-            .hover(
-              function () {
-                $(this).animate({ opacity: "0.5" }, 100);
-              },
-              function () {
-                $(this).animate({ opacity: "1" }, 100);
-              }
-            )
-            .click(function () {
-              let pos_lst = [];
-              let lst = $(this).children();
-              lst.each((idx) => {
-                if (idx == 0) {
-                  $("#m_time_val").val(
-                    Number(lst.eq(idx).text().split(" 초")[0])
-                  );
-                  return;
-                } else {
-                  let val = Number(lst.eq(idx).text());
-                  $("#m" + (idx - 1) + "_value").val(val);
-                  $("#m" + (idx - 1) + "_range").val(val);
-                  pos_lst[idx - 1] = val;
-                }
-              });
-
-              socket.emit("set_motors", { pos_lst: pos_lst });
-            })
-            .dblclick(async function () {
-              let t = $(this).text().split(" 초")[0];
-              if (await confirm_popup(translations["confirm_motion_delete"][lang](t))) {
-                socket.emit("delete_frame", Number(t) * 1000);
-                $(this).remove();
-              }
-            })
-        );
-      }
-    }
-  });
+  // dispMotion() defined globally above
 
   $("#export_motion_bt").on("click", function() {
     let motion_a = document.createElement("a");
@@ -863,7 +853,7 @@ const getMotions = (socket) => {
   // 테이블 초기화
   $("#init_frame_bt").on("click", async function () {
     if (await confirm_popup(translations["confirm_motion_delete_all"][lang])) {
-      socket.emit("init_frame");
+      api('POST', '/api/motion/frame/init').then(d => dispMotion(d));
       $("#motor_table > tbody").empty();
     }
   });
@@ -872,7 +862,7 @@ const getMotions = (socket) => {
   $("#play_frame_bt").on("click", async function () {
     if ($("#motor_table > tbody").text()) {
       let cycle = $("#play_cycle_val").val();
-      socket.emit("play_frame", cycle);
+      api('POST', '/api/motion/frame/play', { cycle: cycle });
     } else {
       await alert_popup(translations["motion_empty"][lang]);
     }
@@ -896,7 +886,7 @@ const getMotions = (socket) => {
 
   // 동작 정지
   $("#stop_frame_bt").on("click", function () {
-    socket.emit("stop_frame");
+    api('POST', '/api/motion/frame/stop');
   });
 
   // 모션 추가
@@ -908,7 +898,7 @@ const getMotions = (socket) => {
       return;
     }  
     if (await confirm_popup(translations["confirm_motion_register"][lang](motionName))) {
-      socket.emit("add_motion", motionName);
+      api('POST', '/api/motion/add', { name: motionName }).then(d => dispMotion(d));
       $("#motion_name_val").val("");
     }
   });
@@ -923,7 +913,7 @@ const getMotions = (socket) => {
     }
 
     if (await confirm_popup(translations["confirm_motion_load"][lang](motionName))) {
-      socket.emit("load_motion", motionName);
+      api('POST', '/api/motion/load', { name: motionName }).then(d => dispMotion(d));
       $("#motion_name_val").val("");
     }
   });
@@ -939,7 +929,7 @@ const getMotions = (socket) => {
   for (idx in sample_motions) {
     $(`#motion_${sample_motions[idx]}_bt`).on("click", function () {
       let i = sample_motions.indexOf($(this).text());
-      socket.emit("load_motion", sample_motions[i]);
+      api('POST', '/api/motion/load', { name: sample_motions[i] }).then(d => dispMotion(d));
     });
   }
 
@@ -952,18 +942,18 @@ const getMotions = (socket) => {
       return;
     }
     if (await confirm_popup(translations["confirm_motion_delete"][lang](motionName))) {
-      socket.emit("delete_motion", motionName);
+      api('POST', '/api/motion/delete', { name: motionName }).then(d => dispMotion(d));
       $("#motion_name_val").val("");
     }
   });
 
   // 모션 삭제
   $("#reset_motion_bt").on("click", async function () {
-    if (await confirm_popup(translations["confirm_motion_delete_all"][lang])) socket.emit("reset_motion");
+    if (await confirm_popup(translations["confirm_motion_delete_all"][lang])) api('POST', '/api/motion/reset').then(d => dispMotion(d));
   });
 };
 
-const getSpeech = (socket) => {
+const getSpeech = () => {
   const max_tts_length = 100;
   $("#s_tts_bt").on("click", async function () {
     if ($("input[name=s_voice_en]:checked").val() == "off") {
@@ -980,7 +970,7 @@ const getSpeech = (socket) => {
       await alert_popup(translations["text_size_limit"][lang](max_tts_length));
       return;
     }
-    socket.emit("tts", {
+    api('POST', '/api/audio/tts', {
       text: string,
       voice_type: $("select[name=s_voice_type]").val(),
       volume: Number($("#volume").val()),
@@ -1002,7 +992,7 @@ const getSpeech = (socket) => {
         await alert_popup(translations["text_size_limit"][lang](max_tts_length));
         return;
       }
-      socket.emit("tts", {
+      api('POST', '/api/audio/tts', {
         text: string,
         voice_type: $("select[name=s_voice_type]").val(),
         volume: Number($("#volume").val()),
@@ -1031,7 +1021,7 @@ const getSpeech = (socket) => {
   });
 
   $("#s_reset_csv_bt").on("click", async function () {
-    socket.emit("reset_csv", {lang: lang});
+    api('POST', '/api/speech/reset_csv', {lang: lang});
     $("#s_upload_csv").val("");
     await alert_popup(translations["reset_ok"][lang]);
   });
@@ -1066,7 +1056,7 @@ const getSpeech = (socket) => {
       }, 600);
 
       setTimeout(function () {
-        socket.emit("question", {
+        api('POST', '/api/speech/question', {
           question: q.toLowerCase(),
           n: lang=="ko"?2:4,
           voice_en: $("input[name=s_voice_en]:checked").val(),
@@ -1099,7 +1089,7 @@ const getSpeech = (socket) => {
     }, 600);
 
     setTimeout(function () {
-      socket.emit("question", {
+      api('POST', '/api/speech/question', {
         question: q.toLowerCase(),
         n: lang=="ko"?2:4,
         voice_en: $("input[name=s_voice_en]:checked").val(),
@@ -1118,7 +1108,7 @@ const getSpeech = (socket) => {
       return;
     }
 
-    socket.emit("translate", {
+    api('POST', '/api/speech/translate', {
       langtype:$("select[name=s_lang_type]").val(),
       voice_en: $("input[name=s_voice_en]:checked").val(),
       volume: Number($("#volume").val()),
@@ -1134,7 +1124,7 @@ const getSpeech = (socket) => {
         return;
       }
   
-      socket.emit("translate", {
+      api('POST', '/api/speech/translate', {
         langtype:$("select[name=s_lang_type]").val(),
         voice_en: $("input[name=s_voice_en]:checked").val(),
         volume: Number($("#volume").val()),
@@ -1143,15 +1133,6 @@ const getSpeech = (socket) => {
     }
   });
 
-  socket.on("disp_translate", (data) => {
-    $("#s_translate_result_val").val(data);
-  });
-
-
-  socket.on("mic", function (d) {
-    //console.log('mic', d)
-    $("#mic_status").text(d);
-  });
 
   $("#mic_bt").on("click", async function () {
     let tmictime = "#mic_time_val";
@@ -1165,17 +1146,16 @@ const getSpeech = (socket) => {
     }
 
     $("#mic_status").html("<i class='fa-solid fa-fade'>녹음 중</i>");
-    socket.emit("mic", {
-      time: val,
-      volume: Number($("#volume").val()),
-    });
+    $("#mic_status").html("<i class='fa-solid fa-fade'>녹음 중</i>");
+    await api('POST', '/api/audio/mic', { time: val, volume: Number($("#volume").val()) });
+    $("#mic_status").text('완료');
   });
 
-  $("#mic_replay_bt").on("click", function () {
-    socket.emit("mic_replay", { volume: Number($("#volume").val()) });
+  $("#mic_replay_bt").on("click", async function () {
+    await api('POST', '/api/audio/mic/replay', { volume: Number($("#volume").val()) });
   });
 
-  socket.on("disp_speech", function (data) {
+  function dispSpeech(data) {
     if ("answer" in data) {
       $("#s_answer_val").val(data["answer"]);
     }
@@ -1199,8 +1179,7 @@ const getSpeech = (socket) => {
   });
 };
 
-const getSimulations = (socket) => {
-  /* 함수 호출: 부분에 socket 이용한 코드 삽입 */
+const getSimulations = () => {
   let selectFile = null;
   let selectFileContents = [];
   $("#sequence_title").hide();
@@ -1231,7 +1210,7 @@ const getSimulations = (socket) => {
     // play 되는 socket 함수들 cb으로 실행완료 후 동작 넘기도록?
     const tempSocket = {
       sim_play_item: (data) => {
-        socket.emit("sim_play_item", data);
+        api('POST', '/api/simulate/play', data);
       },
       sim_play_items: (data) => {
         playing.status = true;
@@ -1275,52 +1254,48 @@ const getSimulations = (socket) => {
           const itemName = `timeline_row_${timeVal}`;
           handleTimelineItemClick($(`div[name=${itemName}]`));
         });
-        socket.emit("sim_play_items", data);
+        api('POST', '/api/simulate/items/play', {items: data});
       },
       sim_stop_item: (data) => {
-        socket.emit("sim_stop_item", data);
+        api('POST', '/api/simulate/stop', {key: data});
       },
       sim_stop_items: () => {
         playing.status = false;
-        socket.emit("sim_stop_items");
+        api('POST', '/api/simulate/items/stop');
       },
       sim_update_audio: (type, cb) => {
-        socket.on("sim_update_audio", cb);
-        socket.emit("sim_update_audio", type);
+        api('GET', `/api/simulate/audio?p=${encodeURIComponent(type)}`).then(d => cb(d.files));
       },
       sim_update_oled: (type, cb) => {
-        socket.on("sim_update_oled", cb);
-        socket.emit("sim_update_oled", type);
+        api('GET', `/api/simulate/oled?p=${encodeURIComponent(type)}`).then(d => cb(d.files));
       },
       sim_update_motion: (type, cb) => {
-        socket.on("sim_update_motion", cb);
-        socket.emit("sim_update_motion", type);
+        api('GET', `/api/simulate/motion?type=${encodeURIComponent(type)}`).then(d => cb(d.motions));
       },
       sim_add_items: ({ name, data }) => {
-        socket.emit("sim_add_items", { name, data });
+        api('POST', '/api/simulate/items', { name, data });
       },
       sim_remove_items: (name) => {
         if (name) {
-          socket.emit("sim_remove_items", name);
+          api('DELETE', `/api/simulate/items?name=${encodeURIComponent(name)}`);
         } else {
-          socket.emit("sim_remove_items");
+          api('DELETE', '/api/simulate/items');
         }
       },
       sim_load_item: (name, cb) => {
         // 파일
-        socket.on("sim_load_item", (data) => cb({ name, data }));
-        socket.emit("sim_load_item", name);
+        api('GET', `/api/simulate/item?name=${encodeURIComponent(name)}`).then(d => cb({ name, item: d.item }));
       },
       sim_load_items: (cb) => {
         // 목록
-        socket.on("sim_load_items", (data) => cb(data));
-        socket.emit("sim_load_items");
+        api('GET', '/api/simulate/items').then(d => cb(d.items));
       },
     };
     const result = cb ? tempSocket[name](params, cb) : tempSocket[name](params);
     return result;
   };
-  socket.on("sim_result", (res) => {
+  // sim_result is now returned directly from API calls
+  function handleSimResult(res) {
     // 완료 신호 올 경우 상태 변경할 것
     if (typeof res === "object") {
       const [[key, v]] = Object.entries(res);
@@ -2597,20 +2572,20 @@ const handleMenu = (name) => {
   if (name === "speech") {
     $("#s_question_val").val("");
     $("#s_answer_val").val("");
-    socket.emit("disp_speech");
+    api('GET', '/api/speech/chat_list').then(dispSpeech);
   } else if (name === "vision") {
     $("#v_tilt_range").val($("#m5_range").val());
     $("#v_pan_range").val($("#m4_range").val());
     $("#v_location").text(`${$("#m4_range").val()}, ${$("#m5_range").val()}`);
-    socket.emit("disp_vision");
+    api('GET', '/api/vision/type').then(d => { if(d.vision_type) $('#v_func_type').val(d.vision_type); }); startVisionStream();
   } else if (name === "motion") {
-    socket.emit("disp_motion");
+    api('GET', '/api/motion/info').then(dispMotion);
   }
 
-  socket.emit("vision_sleep", name=="vision"?"off":"on");
+  api('POST', '/api/vision/sleep', { sleep: name=="vision"?"off":"on" });
   if (name != "motion") {
-    socket.emit("set_motor", { idx: 0, pos: 0});
-    socket.emit("set_motor", { idx: 6, pos: 0});
+    api('POST', '/api/motion/motor', { idx: 0, pos: 0});
+    api('POST', '/api/motion/motor', { idx: 6, pos: 0});
   }
 
   $("h4#content_header").text(name.toUpperCase());
@@ -2621,11 +2596,11 @@ const handleMenu = (name) => {
   $(`#article_${name}`).show("slide");
 };
 
-getVisions(socket);
-getMotions(socket);
-getSpeech(socket);
-getDevices(socket);
-getSimulations(socket);
+getVisions();
+getMotions();
+getSpeech();
+getDevices();
+getSimulations();
 
 handleMenu("device");
 const menus = $("nav").find("button");

--- a/tools/templates/index.html
+++ b/tools/templates/index.html
@@ -16,7 +16,6 @@
 
     <script src="../static/jquery-3.1.1.min.js"></script>
     <script src="../static/jquery.jsonview.min.js"></script>
-    <script src="../static/socket.io.min.js?ver=240110v1"></script>
   </head>
   <body>
     <header class="title">


### PR DESCRIPTION
… pibo_api

- ide/run_ide.py: Replace fastapi-socketio with SSE broadcast + REST endpoints under /api/ prefix. Add /api/stream SSE endpoint for real-time output/status.
- ide/static/index.js: Replace socket.io client with fetch() + EventSource SSE.
- ide/templates/index.html: Remove socket.io script tag.
- tools/run_tools.py: Replace fastapi-socketio with REST endpoints under /api/. Vision, device, audio, speech, motion, simulation all exposed as REST.
- tools/lib.py: Remove emit_func dependency; store vision frame in instance var for polling by SSE endpoint.
- tools/static/index.js: Replace socket.io client with fetch() + EventSource.
- tools/templates/index.html: Remove socket.io script tag.
- pibo_api/run_api.py: New comprehensive REST API server exposing all openpibo package features (audio, collect, device, motion, oled, speech, camera, vision_detect, vision_face, vision_classify) for frontend/backend separation.

https://claude.ai/code/session_01Vrxf3dR4Ac22KnaFQXHww1